### PR TITLE
feat(core): add Server-Sent Events (SSE) support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -161,6 +161,14 @@
             "taxum": "./src/routing/index.ts",
             "default": "./dist/routing/index.js"
         },
+        "./sse": {
+            "types": [
+                "./dist/sse/index.d.ts",
+                "./src/sse/index.ts"
+            ],
+            "taxum": "./src/sse/index.ts",
+            "default": "./dist/sse/index.js"
+        },
         "./server": {
             "types": [
                 "./dist/server/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -161,14 +161,6 @@
             "taxum": "./src/routing/index.ts",
             "default": "./dist/routing/index.js"
         },
-        "./sse": {
-            "types": [
-                "./dist/sse/index.d.ts",
-                "./src/sse/index.ts"
-            ],
-            "taxum": "./src/sse/index.ts",
-            "default": "./dist/sse/index.js"
-        },
         "./server": {
             "types": [
                 "./dist/server/index.d.ts",
@@ -184,6 +176,14 @@
             ],
             "taxum": "./src/service/index.ts",
             "default": "./dist/service/index.js"
+        },
+        "./sse": {
+            "types": [
+                "./dist/sse/index.d.ts",
+                "./src/sse/index.ts"
+            ],
+            "taxum": "./src/sse/index.ts",
+            "default": "./dist/sse/index.js"
         },
         "./util": {
             "types": [

--- a/packages/core/src/sse/event.ts
+++ b/packages/core/src/sse/event.ts
@@ -1,0 +1,147 @@
+/**
+ * Represents a single Server-Sent Event.
+ *
+ * All fields are optional. At minimum, most events should include {@link SseEvent.data}.
+ *
+ * @example
+ * ```ts
+ * import type { SseEvent } from "@taxum/core/sse";
+ *
+ * const event: SseEvent = {
+ *     event: "message",
+ *     id: "1",
+ *     data: "Hello, world!",
+ * };
+ * ```
+ */
+export type SseEvent = {
+    /**
+     * Comment lines for the event.
+     *
+     * Comments are lines starting with `:` and are ignored by the client. They are useful for
+     * keep-alive messages.
+     *
+     * Must not contain carriage returns (`\r`) or newlines (`\n`).
+     */
+    comment?: string;
+
+    /**
+     * The event type.
+     *
+     * This maps to `addEventListener` on the client-side `EventSource`. If not set, the client
+     * receives the event via the `message` event.
+     *
+     * Must not contain carriage returns (`\r`) or newlines (`\n`).
+     */
+    event?: string;
+
+    /**
+     * The event data.
+     *
+     * Newlines (`\n`), carriage returns (`\r`), and CRLF sequences (`\r\n`) in the data are
+     * automatically split across multiple `data:` lines per the SSE specification.
+     */
+    data?: string;
+
+    /**
+     * The event ID.
+     *
+     * The client sends this as the `Last-Event-ID` header when reconnecting, allowing the server
+     * to resume from the correct position.
+     *
+     * Must not contain carriage returns (`\r`), newlines (`\n`), or null characters (`\0`).
+     */
+    id?: string;
+
+    /**
+     * The reconnection time hint in milliseconds.
+     *
+     * This tells the client how long to wait before attempting to reconnect after the connection
+     * is lost. Must be a non-negative integer.
+     */
+    retry?: number;
+};
+
+const encoder = new TextEncoder();
+
+const serializeComment = (comment: string): string => {
+    if (/[\r\n]/.test(comment)) {
+        throw new Error("Comment must not contain newlines or carriage returns");
+    }
+
+    return `: ${comment}\n`;
+};
+
+const serializeEventType = (event: string): string => {
+    if (/[\r\n]/.test(event)) {
+        throw new Error("Event type must not contain newlines or carriage returns");
+    }
+
+    return `event: ${event}\n`;
+};
+
+const serializeData = (data: string): string => {
+    let output = "";
+
+    for (const line of data.split(/\r\n|\r|\n/)) {
+        output += `data: ${line}\n`;
+    }
+
+    return output;
+};
+
+const serializeId = (id: string): string => {
+    if (/[\r\n\0]/.test(id)) {
+        throw new Error("Event ID must not contain newlines, carriage returns, or null characters");
+    }
+
+    return `id: ${id}\n`;
+};
+
+const serializeRetry = (retry: number): string => {
+    if (!Number.isInteger(retry) || retry < 0) {
+        throw new Error("Retry must be a non-negative integer");
+    }
+
+    return `retry: ${retry}\n`;
+};
+
+/**
+ * Serializes an {@link SseEvent} to the SSE text wire format as bytes.
+ *
+ * The output follows the
+ * [Server-Sent Events specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream).
+ * Each event is terminated by a blank line (`\n`).
+ *
+ * @throws {@link !Error} if the comment contains a carriage return or newline.
+ * @throws {@link !Error} if the event type contains a carriage return or newline.
+ * @throws {@link !Error} if the ID contains a carriage return, newline, or null character.
+ * @throws {@link !Error} if the retry value is not a non-negative integer.
+ */
+export const serializeSseEvent = (event: SseEvent): Uint8Array => {
+    let output = "";
+
+    if (event.comment !== undefined) {
+        output += serializeComment(event.comment);
+    }
+
+    if (event.event !== undefined) {
+        output += serializeEventType(event.event);
+    }
+
+    if (event.data !== undefined) {
+        output += serializeData(event.data);
+    }
+
+    if (event.id !== undefined) {
+        output += serializeId(event.id);
+    }
+
+    if (event.retry !== undefined) {
+        output += serializeRetry(event.retry);
+    }
+
+    output += "\n";
+
+    return encoder.encode(output);
+};

--- a/packages/core/src/sse/index.ts
+++ b/packages/core/src/sse/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Server-Sent Events (SSE) support for streaming responses.
+ *
+ * This module provides types for constructing and sending SSE responses, including event building
+ * and optional keep-alive support.
+ *
+ * @packageDocumentation
+ */
+
+export type { SseEvent } from "./event.js";
+export { Sse, type SseKeepAliveOptions } from "./sse.js";

--- a/packages/core/src/sse/sse.ts
+++ b/packages/core/src/sse/sse.ts
@@ -1,0 +1,167 @@
+import { Body } from "../http/body.js";
+import { HeaderMap } from "../http/headers.js";
+import { HttpResponse } from "../http/response.js";
+import { SizeHint } from "../http/size-hint.js";
+import { StatusCode } from "../http/status.js";
+import { TO_HTTP_RESPONSE, type ToHttpResponse } from "../http/to-response.js";
+import { type SseEvent, serializeSseEvent } from "./event.js";
+
+/**
+ * Options for configuring SSE keep-alive behavior.
+ */
+export type SseKeepAliveOptions = {
+    /**
+     * The interval in milliseconds between keep-alive messages.
+     *
+     * @defaultValue 15000
+     */
+    interval?: number;
+
+    /**
+     * The comment text to send as a keep-alive message.
+     *
+     * @defaultValue "" (empty comment)
+     */
+    comment?: string;
+};
+
+/**
+ * A Server-Sent Events (SSE) response.
+ *
+ * Wraps a stream of {@link SseEvent} objects and implements {@link ToHttpResponse} to produce a
+ * streaming HTTP response with the correct headers for SSE.
+ *
+ * Accepts either a `ReadableStream<SseEvent>` or any `AsyncIterable<SseEvent>` (including async
+ * generators).
+ *
+ * @example Using an async generator:
+ * ```ts
+ * import { Sse, type SseEvent } from "@taxum/core/sse";
+ *
+ * const handler = () => {
+ *     async function* events(): AsyncGenerator<SseEvent> {
+ *         yield { data: "hello" };
+ *         yield { data: "world" };
+ *     }
+ *
+ *     return new Sse(events());
+ * };
+ * ```
+ *
+ * @example With keep-alive to prevent proxy timeouts:
+ * ```ts
+ * const handler = () => new Sse(events()).keepAlive();
+ * ```
+ */
+export class Sse implements ToHttpResponse {
+    private readonly stream: ReadableStream<SseEvent>;
+    private keepAliveOptions: Required<SseKeepAliveOptions> | undefined;
+
+    /**
+     * Creates a new {@link Sse} response from a stream of events.
+     */
+    public constructor(stream: ReadableStream<SseEvent> | AsyncIterable<SseEvent>) {
+        this.stream = stream instanceof ReadableStream ? stream : ReadableStream.from(stream);
+    }
+
+    /**
+     * Enables keep-alive messages to prevent proxy and load balancer timeouts.
+     *
+     * When enabled, a comment line is sent at the configured interval whenever the stream has not
+     * produced an event. This keeps the connection alive without triggering client-side event
+     * handlers.
+     *
+     * @param options - Optional configuration for keep-alive behavior.
+     */
+    public keepAlive(options?: SseKeepAliveOptions): this {
+        this.keepAliveOptions = {
+            interval: options?.interval ?? 15_000,
+            comment: options?.comment ?? "",
+        };
+        return this;
+    }
+
+    public [TO_HTTP_RESPONSE](): HttpResponse {
+        const headers = new HeaderMap();
+        headers.insert("content-type", "text/event-stream");
+        headers.insert("cache-control", "no-cache");
+        headers.insert("connection", "keep-alive");
+
+        const byteStream = this.createByteStream();
+        const body = new Body(byteStream, SizeHint.unbounded());
+
+        return new HttpResponse(StatusCode.OK, headers, body);
+    }
+
+    private createByteStream(): ReadableStream<Uint8Array> {
+        const source = this.stream;
+        const keepAlive = this.keepAliveOptions;
+
+        if (!keepAlive) {
+            return source.pipeThrough(
+                new TransformStream<SseEvent, Uint8Array>({
+                    transform(event, controller) {
+                        controller.enqueue(serializeSseEvent(event));
+                    },
+                }),
+            );
+        }
+
+        const interval = keepAlive.interval;
+        const keepAliveBytes = serializeSseEvent({ comment: keepAlive.comment });
+        let timer: ReturnType<typeof setInterval> | undefined;
+        const reader = source.getReader();
+
+        return new ReadableStream<Uint8Array>({
+            start(controller) {
+                const resetTimer = (): void => {
+                    if (timer !== undefined) {
+                        clearInterval(timer);
+                    }
+
+                    timer = setInterval(() => {
+                        controller.enqueue(keepAliveBytes);
+                    }, interval);
+                };
+
+                const pump = (): void => {
+                    reader
+                        .read()
+                        .then(({ done, value }) => {
+                            if (done) {
+                                if (timer !== undefined) {
+                                    clearInterval(timer);
+                                }
+
+                                controller.close();
+                                return;
+                            }
+
+                            controller.enqueue(serializeSseEvent(value));
+                            resetTimer();
+                            pump();
+                        })
+                        .catch((error: unknown) => {
+                            if (timer !== undefined) {
+                                clearInterval(timer);
+                            }
+
+                            controller.error(error);
+                        });
+                };
+
+                resetTimer();
+                pump();
+            },
+            cancel() {
+                if (timer !== undefined) {
+                    clearInterval(timer);
+                }
+
+                reader.cancel().catch(() => {
+                    // Ignore cancel errors
+                });
+            },
+        });
+    }
+}

--- a/packages/core/src/sse/sse.ts
+++ b/packages/core/src/sse/sse.ts
@@ -1,9 +1,6 @@
-import { Body } from "../http/body.js";
-import { HeaderMap } from "../http/headers.js";
 import { HttpResponse } from "../http/response.js";
-import { SizeHint } from "../http/size-hint.js";
-import { StatusCode } from "../http/status.js";
 import { TO_HTTP_RESPONSE, type ToHttpResponse } from "../http/to-response.js";
+import { getLoggerProxy } from "../logging/index.js";
 import { type SseEvent, serializeSseEvent } from "./event.js";
 
 /**
@@ -12,6 +9,8 @@ import { type SseEvent, serializeSseEvent } from "./event.js";
 export type SseKeepAliveOptions = {
     /**
      * The interval in milliseconds between keep-alive messages.
+     *
+     * Must be a positive finite number.
      *
      * @defaultValue 15000
      */
@@ -33,6 +32,9 @@ export type SseKeepAliveOptions = {
  *
  * Accepts either a `ReadableStream<SseEvent>` or any `AsyncIterable<SseEvent>` (including async
  * generators).
+ *
+ * An instance is single-use: converting it into a response consumes the underlying stream, so a
+ * new instance must be created for each request.
  *
  * @example Using an async generator:
  * ```ts
@@ -56,6 +58,7 @@ export type SseKeepAliveOptions = {
 export class Sse implements ToHttpResponse {
     private readonly stream: ReadableStream<SseEvent>;
     private keepAliveOptions: Required<SseKeepAliveOptions> | undefined;
+    private converted = false;
 
     /**
      * Creates a new {@link Sse} response from a stream of events.
@@ -72,96 +75,105 @@ export class Sse implements ToHttpResponse {
      * handlers.
      *
      * @param options - Optional configuration for keep-alive behavior.
+     * @throws {@link !Error} if the interval is not a positive finite number, or if the instance
+     *         was already converted into a response.
      */
     public keepAlive(options?: SseKeepAliveOptions): this {
+        if (this.converted) {
+            throw new Error(
+                "keepAlive() must be called before the Sse is converted into a response",
+            );
+        }
+
+        const interval = options?.interval ?? 15_000;
+
+        if (!Number.isFinite(interval) || interval <= 0) {
+            throw new Error(
+                `Keep-alive interval must be a positive finite number of milliseconds, got: ${interval}`,
+            );
+        }
+
         this.keepAliveOptions = {
-            interval: options?.interval ?? 15_000,
+            interval,
             comment: options?.comment ?? "",
         };
         return this;
     }
 
+    /**
+     * @throws {@link !Error} if the instance was already converted into a response.
+     */
     public [TO_HTTP_RESPONSE](): HttpResponse {
-        const headers = new HeaderMap();
-        headers.insert("content-type", "text/event-stream");
-        headers.insert("cache-control", "no-cache");
-        headers.insert("connection", "keep-alive");
-
-        const byteStream = this.createByteStream();
-        const body = new Body(byteStream, SizeHint.unbounded());
-
-        return new HttpResponse(StatusCode.OK, headers, body);
-    }
-
-    private createByteStream(): ReadableStream<Uint8Array> {
-        const source = this.stream;
-        const keepAlive = this.keepAliveOptions;
-
-        if (!keepAlive) {
-            return source.pipeThrough(
-                new TransformStream<SseEvent, Uint8Array>({
-                    transform(event, controller) {
-                        controller.enqueue(serializeSseEvent(event));
-                    },
-                }),
+        if (this.converted) {
+            throw new Error(
+                "An Sse instance can only be converted into a response once; create a new instance for each request",
             );
         }
 
-        const interval = keepAlive.interval;
-        const keepAliveBytes = serializeSseEvent({ comment: keepAlive.comment });
-        let timer: ReturnType<typeof setInterval> | undefined;
-        const reader = source.getReader();
+        this.converted = true;
 
-        return new ReadableStream<Uint8Array>({
-            start(controller) {
-                const resetTimer = (): void => {
-                    if (timer !== undefined) {
-                        clearInterval(timer);
+        return HttpResponse.builder()
+            .header("content-type", "text/event-stream")
+            .header("cache-control", "no-cache")
+            .body(this.createByteStream());
+    }
+
+    private createByteStream(): ReadableStream<Uint8Array> {
+        const serialized = this.stream.pipeThrough(
+            new TransformStream<SseEvent, Uint8Array>({
+                transform: (event, controller) => {
+                    try {
+                        controller.enqueue(serializeSseEvent(event));
+                    } catch (error) {
+                        // The response headers are already sent when this happens, so the error
+                        // only surfaces as an aborted connection; logging is the sole signal
+                        // pointing at the invalid event.
+                        getLoggerProxy().error("Failed to serialize SSE event", { error });
+                        throw error;
                     }
+                },
+            }),
+        );
 
-                    timer = setInterval(() => {
-                        controller.enqueue(keepAliveBytes);
-                    }, interval);
-                };
+        if (!this.keepAliveOptions) {
+            return serialized;
+        }
 
-                const pump = (): void => {
-                    reader
-                        .read()
-                        .then(({ done, value }) => {
-                            if (done) {
-                                if (timer !== undefined) {
-                                    clearInterval(timer);
-                                }
-
-                                controller.close();
-                                return;
-                            }
-
-                            controller.enqueue(serializeSseEvent(value));
-                            resetTimer();
-                            pump();
-                        })
-                        .catch((error: unknown) => {
-                            if (timer !== undefined) {
-                                clearInterval(timer);
-                            }
-
-                            controller.error(error);
-                        });
-                };
-
-                resetTimer();
-                pump();
-            },
-            cancel() {
-                if (timer !== undefined) {
-                    clearInterval(timer);
-                }
-
-                reader.cancel().catch(() => {
-                    // Ignore cancel errors
-                });
-            },
-        });
+        return serialized.pipeThrough(createKeepAliveTransform(this.keepAliveOptions));
     }
 }
+
+const createKeepAliveTransform = (
+    options: Required<SseKeepAliveOptions>,
+): TransformStream<Uint8Array, Uint8Array> => {
+    const keepAliveBytes = serializeSseEvent({ comment: options.comment });
+    let timer: ReturnType<typeof setInterval>;
+
+    return new TransformStream<Uint8Array, Uint8Array>(
+        {
+            start: (controller) => {
+                timer = setInterval(() => {
+                    // Skip when the consumer isn't keeping up: a buffered keep-alive serves no
+                    // purpose and would only grow the queue of a stalled connection.
+                    if ((controller.desiredSize ?? 0) > 0) {
+                        controller.enqueue(keepAliveBytes);
+                    }
+                }, options.interval);
+            },
+            transform: (chunk, controller) => {
+                controller.enqueue(chunk);
+                timer.refresh();
+            },
+            flush: () => {
+                clearInterval(timer);
+            },
+            cancel: () => {
+                clearInterval(timer);
+            },
+        },
+        undefined,
+        // The readable side defaults to a high water mark of 0, under which desiredSize never
+        // rises above zero and the keep-alive check above would suppress every message.
+        { highWaterMark: 1 },
+    );
+};

--- a/packages/core/test/sse/event.test.ts
+++ b/packages/core/test/sse/event.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { serializeSseEvent } from "../../src/sse/event.js";
+
+const decoder = new TextDecoder();
+const serialize = (event: Parameters<typeof serializeSseEvent>[0]): string =>
+    decoder.decode(serializeSseEvent(event));
+
+describe("sse:serializeSseEvent", () => {
+    describe("data", () => {
+        it("serializes a simple data field", () => {
+            assert.equal(serialize({ data: "hello" }), "data: hello\n\n");
+        });
+
+        it("splits multi-line data with LF into multiple data fields", () => {
+            assert.equal(
+                serialize({ data: "line1\nline2\nline3" }),
+                "data: line1\ndata: line2\ndata: line3\n\n",
+            );
+        });
+
+        it("splits multi-line data with CR into multiple data fields", () => {
+            assert.equal(
+                serialize({ data: "line1\rline2\rline3" }),
+                "data: line1\ndata: line2\ndata: line3\n\n",
+            );
+        });
+
+        it("splits multi-line data with CRLF into multiple data fields", () => {
+            assert.equal(
+                serialize({ data: "line1\r\nline2\r\nline3" }),
+                "data: line1\ndata: line2\ndata: line3\n\n",
+            );
+        });
+
+        it("handles empty data", () => {
+            assert.equal(serialize({ data: "" }), "data: \n\n");
+        });
+    });
+
+    describe("event", () => {
+        it("serializes the event type", () => {
+            assert.equal(
+                serialize({ event: "update", data: "test" }),
+                "event: update\ndata: test\n\n",
+            );
+        });
+
+        it("throws when event type contains a newline", () => {
+            assert.throws(() => serializeSseEvent({ event: "a\nb" }), {
+                message: "Event type must not contain newlines or carriage returns",
+            });
+        });
+
+        it("throws when event type contains a carriage return", () => {
+            assert.throws(() => serializeSseEvent({ event: "a\rb" }), {
+                message: "Event type must not contain newlines or carriage returns",
+            });
+        });
+    });
+
+    describe("id", () => {
+        it("serializes the event ID", () => {
+            assert.equal(serialize({ id: "42", data: "test" }), "data: test\nid: 42\n\n");
+        });
+
+        it("throws when ID contains a newline", () => {
+            assert.throws(() => serializeSseEvent({ id: "a\nb" }), {
+                message: "Event ID must not contain newlines, carriage returns, or null characters",
+            });
+        });
+
+        it("throws when ID contains a carriage return", () => {
+            assert.throws(() => serializeSseEvent({ id: "a\rb" }), {
+                message: "Event ID must not contain newlines, carriage returns, or null characters",
+            });
+        });
+
+        it("throws when ID contains a null character", () => {
+            assert.throws(() => serializeSseEvent({ id: "a\0b" }), {
+                message: "Event ID must not contain newlines, carriage returns, or null characters",
+            });
+        });
+    });
+
+    describe("retry", () => {
+        it("serializes the retry field", () => {
+            assert.equal(serialize({ retry: 5000, data: "test" }), "data: test\nretry: 5000\n\n");
+        });
+
+        it("allows zero as retry value", () => {
+            assert.equal(serialize({ retry: 0 }), "retry: 0\n\n");
+        });
+
+        it("throws for negative values", () => {
+            assert.throws(() => serializeSseEvent({ retry: -1 }), {
+                message: "Retry must be a non-negative integer",
+            });
+        });
+
+        it("throws for non-integer values", () => {
+            assert.throws(() => serializeSseEvent({ retry: 1.5 }), {
+                message: "Retry must be a non-negative integer",
+            });
+        });
+    });
+
+    describe("comment", () => {
+        it("serializes a comment line", () => {
+            assert.equal(serialize({ comment: "ping" }), ": ping\n\n");
+        });
+
+        it("handles empty comment", () => {
+            assert.equal(serialize({ comment: "" }), ": \n\n");
+        });
+
+        it("throws when comment contains a newline", () => {
+            assert.throws(() => serializeSseEvent({ comment: "a\nb" }), {
+                message: "Comment must not contain newlines or carriage returns",
+            });
+        });
+
+        it("throws when comment contains a carriage return", () => {
+            assert.throws(() => serializeSseEvent({ comment: "a\rb" }), {
+                message: "Comment must not contain newlines or carriage returns",
+            });
+        });
+    });
+
+    describe("serialization order", () => {
+        it("serializes fields in spec order: comment, event, data, id, retry", () => {
+            assert.equal(
+                serialize({ retry: 3000, id: "1", data: "hello", event: "msg", comment: "note" }),
+                ": note\nevent: msg\ndata: hello\nid: 1\nretry: 3000\n\n",
+            );
+        });
+
+        it("serializes an empty event as just a blank line", () => {
+            assert.equal(serialize({}), "\n");
+        });
+    });
+});

--- a/packages/core/test/sse/sse.test.ts
+++ b/packages/core/test/sse/sse.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import consumers from "node:stream/consumers";
+import { describe, it } from "node:test";
+import { TO_HTTP_RESPONSE } from "../../src/http/index.js";
+import { Sse, type SseEvent } from "../../src/sse/index.js";
+
+const collectStream = async (sse: Sse): Promise<string> => {
+    const response = sse[TO_HTTP_RESPONSE]();
+    return consumers.text(response.body.readable);
+};
+
+type StreamControl = {
+    stream: ReadableStream<SseEvent>;
+    enqueue: (event: SseEvent) => void;
+    close: () => void;
+};
+
+const createControllableStream = (): StreamControl => {
+    let enqueue: ((event: SseEvent) => void) | undefined;
+    let close: (() => void) | undefined;
+
+    const stream = new ReadableStream<SseEvent>({
+        start(controller) {
+            enqueue = (event) => controller.enqueue(event);
+            close = () => controller.close();
+        },
+    });
+
+    assert(enqueue);
+    assert(close);
+
+    return { stream, enqueue, close };
+};
+
+describe("sse:Sse", () => {
+    describe("response headers", () => {
+        it("sets content-type to text/event-stream", () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.close();
+                },
+            });
+            const response = new Sse(stream)[TO_HTTP_RESPONSE]();
+            assert.equal(response.headers.get("content-type")?.value, "text/event-stream");
+        });
+
+        it("sets cache-control to no-cache", () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.close();
+                },
+            });
+            const response = new Sse(stream)[TO_HTTP_RESPONSE]();
+            assert.equal(response.headers.get("cache-control")?.value, "no-cache");
+        });
+
+        it("sets connection to keep-alive", () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.close();
+                },
+            });
+            const response = new Sse(stream)[TO_HTTP_RESPONSE]();
+            assert.equal(response.headers.get("connection")?.value, "keep-alive");
+        });
+
+        it("returns 200 OK status", () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.close();
+                },
+            });
+            const response = new Sse(stream)[TO_HTTP_RESPONSE]();
+            assert.equal(response.status.code, 200);
+        });
+    });
+
+    describe("async iterable support", () => {
+        it("accepts an async generator", async () => {
+            async function* events(): AsyncGenerator<SseEvent> {
+                yield { data: "one" };
+                yield { data: "two" };
+            }
+
+            const result = await collectStream(new Sse(events()));
+            assert.equal(result, "data: one\n\ndata: two\n\n");
+        });
+
+        it("handles an empty async generator", async () => {
+            async function* events(): AsyncGenerator<SseEvent> {
+                // yields nothing
+            }
+
+            const result = await collectStream(new Sse(events()));
+            assert.equal(result, "");
+        });
+
+        it("works with keep-alive", async () => {
+            async function* events(): AsyncGenerator<SseEvent> {
+                yield { data: "hello" };
+            }
+
+            const sse = new Sse(events()).keepAlive({ interval: 50 });
+            const result = await collectStream(sse);
+            assert.equal(result, "data: hello\n\n");
+        });
+    });
+
+    describe("stream transformation", () => {
+        it("transforms a single event to bytes", async () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.enqueue({ data: "hello" });
+                    controller.close();
+                },
+            });
+
+            const result = await collectStream(new Sse(stream));
+            assert.equal(result, "data: hello\n\n");
+        });
+
+        it("transforms multiple events to bytes", async () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.enqueue({ event: "msg", data: "first" });
+                    controller.enqueue({ event: "msg", id: "2", data: "second" });
+                    controller.close();
+                },
+            });
+
+            const result = await collectStream(new Sse(stream));
+            assert.equal(result, "event: msg\ndata: first\n\nevent: msg\ndata: second\nid: 2\n\n");
+        });
+
+        it("handles an empty stream", async () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.close();
+                },
+            });
+
+            const result = await collectStream(new Sse(stream));
+            assert.equal(result, "");
+        });
+
+        it("propagates stream errors", async () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.error(new Error("stream failed"));
+                },
+            });
+
+            await assert.rejects(() => collectStream(new Sse(stream)), {
+                message: "stream failed",
+            });
+        });
+    });
+
+    describe("keep-alive", () => {
+        it("sends keep-alive comment when stream is idle", async () => {
+            const { stream, enqueue, close } = createControllableStream();
+
+            const sse = new Sse(stream).keepAlive({ interval: 50 });
+            const response = sse[TO_HTTP_RESPONSE]();
+            const reader = response.body.readable.getReader();
+
+            // Wait for keep-alive to fire
+            await new Promise((resolve) => setTimeout(resolve, 80));
+
+            const { value: keepAliveChunk } = await reader.read();
+            const decoded = new TextDecoder().decode(keepAliveChunk);
+            assert.equal(decoded, ": \n\n");
+
+            // Send a real event and close
+            enqueue({ data: "test" });
+            close();
+
+            const { value: eventChunk } = await reader.read();
+            assert.equal(new TextDecoder().decode(eventChunk), "data: test\n\n");
+
+            const { done } = await reader.read();
+            assert.equal(done, true);
+        });
+
+        it("uses custom keep-alive comment", async () => {
+            const { stream, close } = createControllableStream();
+
+            const sse = new Sse(stream).keepAlive({ interval: 50, comment: "ping" });
+            const response = sse[TO_HTTP_RESPONSE]();
+            const reader = response.body.readable.getReader();
+
+            // Wait for keep-alive to fire
+            await new Promise((resolve) => setTimeout(resolve, 80));
+
+            const { value: keepAliveChunk } = await reader.read();
+            assert.equal(new TextDecoder().decode(keepAliveChunk), ": ping\n\n");
+
+            close();
+            reader.cancel();
+        });
+
+        it("resets keep-alive timer when an event is sent", async () => {
+            const { stream, enqueue, close } = createControllableStream();
+
+            const sse = new Sse(stream).keepAlive({ interval: 100 });
+            const response = sse[TO_HTTP_RESPONSE]();
+            const reader = response.body.readable.getReader();
+
+            // Send an event before keep-alive fires
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            enqueue({ data: "early" });
+
+            const { value: eventChunk } = await reader.read();
+            assert.equal(new TextDecoder().decode(eventChunk), "data: early\n\n");
+
+            // Wait less than the interval — no keep-alive should fire yet
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            close();
+
+            // Should get end-of-stream, not a keep-alive
+            const { done } = await reader.read();
+            assert.equal(done, true);
+        });
+
+        it("cleans up timer on cancel", async () => {
+            const stream = new ReadableStream<SseEvent>({
+                start() {
+                    // Never closes — simulates a long-lived stream
+                },
+            });
+
+            const sse = new Sse(stream).keepAlive({ interval: 50 });
+            const response = sse[TO_HTTP_RESPONSE]();
+            const reader = response.body.readable.getReader();
+
+            // Cancel immediately
+            await reader.cancel();
+
+            // If the timer wasn't cleaned up, the test would hang or leak
+            assert.ok(true);
+        });
+
+        it("ignores cancel errors from the source stream", async () => {
+            const stream = new ReadableStream<SseEvent>({
+                start() {
+                    // Never closes
+                },
+                cancel() {
+                    throw new Error("cancel rejected");
+                },
+            });
+
+            const sse = new Sse(stream).keepAlive({ interval: 50 });
+            const response = sse[TO_HTTP_RESPONSE]();
+            const reader = response.body.readable.getReader();
+
+            // Should not throw despite source cancel rejecting
+            await reader.cancel();
+            assert.ok(true);
+        });
+
+        it("uses default keep-alive options", async () => {
+            const { stream, close } = createControllableStream();
+
+            const sse = new Sse(stream).keepAlive();
+
+            // Verify it doesn't throw and creates a valid response
+            const response = sse[TO_HTTP_RESPONSE]();
+            assert.equal(response.status.code, 200);
+
+            close();
+            // Drain the stream
+            await consumers.text(response.body.readable);
+        });
+
+        it("propagates stream errors with keep-alive enabled", async () => {
+            const stream = new ReadableStream<SseEvent>({
+                start(controller) {
+                    controller.error(new Error("keep-alive stream failed"));
+                },
+            });
+
+            const sse = new Sse(stream).keepAlive({ interval: 50 });
+
+            await assert.rejects(() => collectStream(sse), {
+                message: "keep-alive stream failed",
+            });
+        });
+    });
+});

--- a/packages/core/test/sse/sse.test.ts
+++ b/packages/core/test/sse/sse.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import consumers from "node:stream/consumers";
 import { describe, it } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { TO_HTTP_RESPONSE } from "../../src/http/index.js";
 import { Sse, type SseEvent } from "../../src/sse/index.js";
 
@@ -8,6 +9,14 @@ const collectStream = async (sse: Sse): Promise<string> => {
     const response = sse[TO_HTTP_RESPONSE]();
     return consumers.text(response.body.readable);
 };
+
+const withTimeout = async (promise: Promise<void>, ms: number, message: string): Promise<void> =>
+    Promise.race([
+        promise,
+        delay(ms).then(() => {
+            throw new Error(message);
+        }),
+    ]);
 
 type StreamControl = {
     stream: ReadableStream<SseEvent>;
@@ -20,7 +29,7 @@ const createControllableStream = (): StreamControl => {
     let close: (() => void) | undefined;
 
     const stream = new ReadableStream<SseEvent>({
-        start(controller) {
+        start: (controller) => {
             enqueue = (event) => controller.enqueue(event);
             close = () => controller.close();
         },
@@ -36,7 +45,7 @@ describe("sse:Sse", () => {
     describe("response headers", () => {
         it("sets content-type to text/event-stream", () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.close();
                 },
             });
@@ -46,7 +55,7 @@ describe("sse:Sse", () => {
 
         it("sets cache-control to no-cache", () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.close();
                 },
             });
@@ -54,24 +63,52 @@ describe("sse:Sse", () => {
             assert.equal(response.headers.get("cache-control")?.value, "no-cache");
         });
 
-        it("sets connection to keep-alive", () => {
+        it("does not set a connection header", () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.close();
                 },
             });
             const response = new Sse(stream)[TO_HTTP_RESPONSE]();
-            assert.equal(response.headers.get("connection")?.value, "keep-alive");
+            assert.equal(response.headers.get("connection"), null);
         });
 
         it("returns 200 OK status", () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.close();
                 },
             });
             const response = new Sse(stream)[TO_HTTP_RESPONSE]();
             assert.equal(response.status.code, 200);
+        });
+    });
+
+    describe("single use", () => {
+        it("throws when converted twice", () => {
+            const sse = new Sse(
+                new ReadableStream<SseEvent>({
+                    start: (controller) => {
+                        controller.close();
+                    },
+                }),
+            );
+
+            sse[TO_HTTP_RESPONSE]();
+            assert.throws(() => sse[TO_HTTP_RESPONSE](), /only be converted into a response once/);
+        });
+
+        it("throws when keepAlive is called after conversion", () => {
+            const sse = new Sse(
+                new ReadableStream<SseEvent>({
+                    start: (controller) => {
+                        controller.close();
+                    },
+                }),
+            );
+
+            sse[TO_HTTP_RESPONSE]();
+            assert.throws(() => sse.keepAlive(), /before the Sse is converted/);
         });
     });
 
@@ -109,7 +146,7 @@ describe("sse:Sse", () => {
     describe("stream transformation", () => {
         it("transforms a single event to bytes", async () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.enqueue({ data: "hello" });
                     controller.close();
                 },
@@ -121,7 +158,7 @@ describe("sse:Sse", () => {
 
         it("transforms multiple events to bytes", async () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.enqueue({ event: "msg", data: "first" });
                     controller.enqueue({ event: "msg", id: "2", data: "second" });
                     controller.close();
@@ -134,7 +171,7 @@ describe("sse:Sse", () => {
 
         it("handles an empty stream", async () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.close();
                 },
             });
@@ -145,7 +182,7 @@ describe("sse:Sse", () => {
 
         it("propagates stream errors", async () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.error(new Error("stream failed"));
                 },
             });
@@ -153,6 +190,35 @@ describe("sse:Sse", () => {
             await assert.rejects(() => collectStream(new Sse(stream)), {
                 message: "stream failed",
             });
+        });
+
+        it("logs and cancels the source when an event fails to serialize", async (t) => {
+            const spy = t.mock.method(console, "error", () => {
+                // Suppress actual console.error output.
+            });
+
+            const { promise: cancellation, resolve: cancelled } = Promise.withResolvers<void>();
+
+            const stream = new ReadableStream<SseEvent>({
+                pull: (controller) => {
+                    controller.enqueue({ retry: 1.5 });
+                },
+                cancel: () => {
+                    cancelled();
+                },
+            });
+
+            const sse = new Sse(stream).keepAlive({ interval: 50 });
+            const reader = sse[TO_HTTP_RESPONSE]().body.readable.getReader();
+
+            await assert.rejects(async () => {
+                while (!(await reader.read()).done) {
+                    // Drain until the serialization error surfaces.
+                }
+            });
+
+            await withTimeout(cancellation, 500, "source was not cancelled");
+            assert.match(spy.mock.calls[0].arguments[0], /Failed to serialize SSE event/i);
         });
     });
 
@@ -164,14 +230,12 @@ describe("sse:Sse", () => {
             const response = sse[TO_HTTP_RESPONSE]();
             const reader = response.body.readable.getReader();
 
-            // Wait for keep-alive to fire
-            await new Promise((resolve) => setTimeout(resolve, 80));
+            await delay(80);
 
             const { value: keepAliveChunk } = await reader.read();
             const decoded = new TextDecoder().decode(keepAliveChunk);
             assert.equal(decoded, ": \n\n");
 
-            // Send a real event and close
             enqueue({ data: "test" });
             close();
 
@@ -189,8 +253,7 @@ describe("sse:Sse", () => {
             const response = sse[TO_HTTP_RESPONSE]();
             const reader = response.body.readable.getReader();
 
-            // Wait for keep-alive to fire
-            await new Promise((resolve) => setTimeout(resolve, 80));
+            await delay(80);
 
             const { value: keepAliveChunk } = await reader.read();
             assert.equal(new TextDecoder().decode(keepAliveChunk), ": ping\n\n");
@@ -206,46 +269,73 @@ describe("sse:Sse", () => {
             const response = sse[TO_HTTP_RESPONSE]();
             const reader = response.body.readable.getReader();
 
-            // Send an event before keep-alive fires
-            await new Promise((resolve) => setTimeout(resolve, 30));
+            await delay(30);
             enqueue({ data: "early" });
 
             const { value: eventChunk } = await reader.read();
             assert.equal(new TextDecoder().decode(eventChunk), "data: early\n\n");
 
-            // Wait less than the interval — no keep-alive should fire yet
-            await new Promise((resolve) => setTimeout(resolve, 50));
+            // Wait less than the interval, so no keep-alive may fire before the close.
+            await delay(50);
             close();
 
-            // Should get end-of-stream, not a keep-alive
             const { done } = await reader.read();
             assert.equal(done, true);
         });
 
-        it("cleans up timer on cancel", async () => {
+        it("rejects an invalid interval", () => {
+            const stream = new ReadableStream<SseEvent>();
+
+            for (const interval of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+                assert.throws(
+                    () => new Sse(stream).keepAlive({ interval }),
+                    /must be a positive finite number/,
+                );
+            }
+        });
+
+        it("respects backpressure from a slow consumer", async () => {
+            let pullCount = 0;
+
             const stream = new ReadableStream<SseEvent>({
-                start() {
-                    // Never closes — simulates a long-lived stream
+                pull: (controller) => {
+                    pullCount++;
+                    controller.enqueue({ data: "x" });
+                },
+            });
+
+            const sse = new Sse(stream).keepAlive({ interval: 1000 });
+            const reader = sse[TO_HTTP_RESPONSE]().body.readable.getReader();
+
+            await delay(50);
+
+            assert.ok(
+                pullCount <= 5,
+                `source was pulled ${pullCount} times without a reading consumer`,
+            );
+
+            await reader.cancel();
+        });
+
+        it("propagates cancel to the source stream", async () => {
+            const { promise: cancellation, resolve: cancelled } = Promise.withResolvers<void>();
+
+            const stream = new ReadableStream<SseEvent>({
+                cancel: () => {
+                    cancelled();
                 },
             });
 
             const sse = new Sse(stream).keepAlive({ interval: 50 });
             const response = sse[TO_HTTP_RESPONSE]();
-            const reader = response.body.readable.getReader();
 
-            // Cancel immediately
-            await reader.cancel();
-
-            // If the timer wasn't cleaned up, the test would hang or leak
-            assert.ok(true);
+            await response.body.readable.getReader().cancel();
+            await withTimeout(cancellation, 500, "source was not cancelled");
         });
 
         it("ignores cancel errors from the source stream", async () => {
             const stream = new ReadableStream<SseEvent>({
-                start() {
-                    // Never closes
-                },
-                cancel() {
+                cancel: () => {
                     throw new Error("cancel rejected");
                 },
             });
@@ -254,28 +344,23 @@ describe("sse:Sse", () => {
             const response = sse[TO_HTTP_RESPONSE]();
             const reader = response.body.readable.getReader();
 
-            // Should not throw despite source cancel rejecting
-            await reader.cancel();
-            assert.ok(true);
+            await assert.doesNotReject(() => reader.cancel());
         });
 
         it("uses default keep-alive options", async () => {
             const { stream, close } = createControllableStream();
 
             const sse = new Sse(stream).keepAlive();
-
-            // Verify it doesn't throw and creates a valid response
             const response = sse[TO_HTTP_RESPONSE]();
             assert.equal(response.status.code, 200);
 
             close();
-            // Drain the stream
             await consumers.text(response.body.readable);
         });
 
         it("propagates stream errors with keep-alive enabled", async () => {
             const stream = new ReadableStream<SseEvent>({
-                start(controller) {
+                start: (controller) => {
                     controller.error(new Error("keep-alive stream failed"));
                 },
             });

--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -100,6 +100,10 @@ export default withMermaid(
                                 link: "/guide/core-concepts/logging",
                             },
                             {
+                                text: "Server-Sent Events",
+                                link: "/guide/core-concepts/sse",
+                            },
+                            {
                                 text: "Testing",
                                 link: "/guide/core-concepts/testing",
                             },

--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -100,6 +100,10 @@ export default withMermaid(
                                 link: "/guide/core-concepts/logging",
                             },
                             {
+                                text: "Server-Sent Events",
+                                link: "/guide/core-concepts/sse",
+                            },
+                            {
                                 text: "Graceful Shutdown",
                                 link: "/guide/core-concepts/graceful-shutdown",
                             },

--- a/packages/docs/src/guide/core-concepts/sse.md
+++ b/packages/docs/src/guide/core-concepts/sse.md
@@ -1,0 +1,169 @@
+---
+description: How to stream Server-Sent Events (SSE) from handlers.
+---
+
+# Server-Sent Events
+
+Server-Sent Events (SSE) allow your server to push events to the client over a long-lived HTTP connection. The browser's
+built-in [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) API handles reconnection
+automatically, making SSE ideal for real-time updates like notifications, live feeds, or AI token streaming.
+
+## Basic usage
+
+Return an `Sse` instance from your handler. The simplest approach is to use an async generator:
+
+```ts
+import { Sse, type SseEvent } from "@taxum/core/sse";
+import { m, Router } from "@taxum/core/routing";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const handler = () => {
+    async function* events(): AsyncGenerator<SseEvent> {
+        for (let i = 0; i <= 10; i++) {
+            yield {
+                event: "tick",
+                id: String(i),
+                data: `Counter: ${i}`,
+            };
+
+            await sleep(1000);
+        }
+    }
+
+    return new Sse(events());
+};
+
+const router = new Router().route("/events", m.get(handler));
+```
+
+You can also pass a `ReadableStream<SseEvent>` if you prefer:
+
+```ts
+import { Sse, type SseEvent } from "@taxum/core/sse";
+
+const handler = () => {
+    const stream = new ReadableStream<SseEvent>({
+        start: (controller) => {
+            controller.enqueue({ data: "hello" });
+            controller.close();
+        },
+    });
+
+    return new Sse(stream);
+};
+```
+
+The `Sse` class sets the following response headers automatically:
+
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `Connection: keep-alive`
+
+## Event fields
+
+`SseEvent` is a plain object. All fields are optional:
+
+```ts
+const event: SseEvent = {
+    event: "update",       // Event type (maps to addEventListener on the client)
+    id: "42",              // Event ID (sent as Last-Event-ID on reconnect)
+    data: "hello world",   // Event data
+    retry: 5000,           // Reconnection hint in milliseconds
+    comment: "metadata",   // Comment line (ignored by the client)
+};
+```
+
+### JSON data
+
+Serialize JSON data with `JSON.stringify()`:
+
+```ts
+const event: SseEvent = {
+    event: "price",
+    data: JSON.stringify({ symbol: "AAPL", price: 150.25 }),
+};
+```
+
+### Multi-line data
+
+Newlines (`\n`), carriage returns (`\r`), and CRLF sequences in data are automatically split across multiple `data:`
+lines per the SSE specification:
+
+```ts
+const event: SseEvent = {
+    data: "line one\nline two\nline three",
+};
+// Produces:
+// data: line one
+// data: line two
+// data: line three
+```
+
+### Validation
+
+The `event` and `comment` fields must not contain newlines or carriage returns. The `id` field must additionally not
+contain null characters. The `retry` field must be a non-negative integer. Invalid values cause an error when the event
+is serialized.
+
+## Keep-alive
+
+Proxies and load balancers often close idle connections. Enable keep-alive to send periodic comment lines that keep the
+connection open:
+
+```ts
+new Sse(stream).keepAlive()
+```
+
+The default interval is 15 seconds with an empty comment. You can customize both:
+
+```ts
+new Sse(stream).keepAlive({
+    interval: 30_000,
+    comment: "ping",
+})
+```
+
+Keep-alive messages are only sent when the stream is idle. The timer resets each time a real event is emitted.
+
+## Client-side reconnection
+
+The browser's `EventSource` automatically reconnects when the connection drops. To support resuming from the correct
+position:
+
+1. Set an `id` on each event
+2. On reconnect, the browser sends the last received ID as the `Last-Event-ID` request header
+3. Read this header in your handler to resume the stream
+
+```ts
+import { Sse, type SseEvent } from "@taxum/core/sse";
+import { m, Router } from "@taxum/core/routing";
+import type { HttpRequest } from "@taxum/core/http";
+
+const handler = (req: HttpRequest) => {
+    const lastId = req.headers.get("last-event-id")?.value;
+    const startFrom = lastId ? Number.parseInt(lastId, 10) + 1 : 0;
+
+    async function* events(): AsyncGenerator<SseEvent> {
+        for (let i = startFrom; i < 100; i++) {
+            yield {
+                id: String(i),
+                data: `Event ${i}`,
+            };
+        }
+    }
+
+    return new Sse(events());
+};
+
+const router = new Router().route("/events", m.get(handler));
+```
+
+Use `retry` to tell the client how long to wait before reconnecting:
+
+```ts
+const event: SseEvent = {
+    retry: 5000,
+    data: "hello",
+};
+```

--- a/packages/docs/src/guide/core-concepts/sse.md
+++ b/packages/docs/src/guide/core-concepts/sse.md
@@ -167,3 +167,60 @@ const event: SseEvent = {
     data: "hello",
 };
 ```
+
+## Graceful shutdown
+
+An SSE stream never ends on its own, so it blocks a [graceful shutdown](/guide/core-concepts/graceful-shutdown) until
+the `shutdownTimeout` force-closes the connection. End the stream cooperatively instead: the `SHUTDOWN_SIGNAL`
+extension aborts the moment shutdown begins, while the connection is still writable, so you can send a final event
+with a `retry` hint before closing:
+
+```ts
+import { extension } from "@taxum/core/extract";
+import { createExtractHandler } from "@taxum/core/routing";
+import { SHUTDOWN_SIGNAL } from "@taxum/core/server";
+import { Sse, type SseEvent } from "@taxum/core/sse";
+
+const handler = createExtractHandler(extension(SHUTDOWN_SIGNAL, true)).handler(
+    (shutdownSignal) => {
+        async function* events(): AsyncGenerator<SseEvent> {
+            let counter = 0;
+
+            while (!shutdownSignal.aborted) {
+                yield { id: String(counter++), data: "tick" };
+                await sleep(1000);
+            }
+
+            yield { retry: 5000, comment: "server shutting down" };
+        }
+
+        return new Sse(events());
+    },
+);
+```
+
+The client's `EventSource` reconnects after the `retry` delay, resuming against a fresh server instance via
+`Last-Event-ID` as shown above. When every stream ends cooperatively, the server shuts down without waiting for the
+timeout.
+
+## Client disconnects
+
+When the client disconnects, the event stream is cancelled automatically. For an async generator this runs its
+`finally` blocks, which is the place to release resources:
+
+```ts
+async function* events(): AsyncGenerator<SseEvent> {
+    const subscription = pubsub.subscribe("news");
+
+    try {
+        for await (const message of subscription) {
+            yield { data: message };
+        }
+    } finally {
+        subscription.unsubscribe();
+    }
+}
+```
+
+If your producer performs work outside the generator, the `DISCONNECT_SIGNAL` extension provides the same information
+as an `AbortSignal`; see [Graceful Shutdown](/guide/core-concepts/graceful-shutdown#disconnect-signal).

--- a/packages/docs/src/guide/core-concepts/sse.md
+++ b/packages/docs/src/guide/core-concepts/sse.md
@@ -58,7 +58,6 @@ The `Sse` class sets the following response headers automatically:
 
 - `Content-Type: text/event-stream`
 - `Cache-Control: no-cache`
-- `Connection: keep-alive`
 
 ## Event fields
 
@@ -141,8 +140,8 @@ import { m, Router } from "@taxum/core/routing";
 import type { HttpRequest } from "@taxum/core/http";
 
 const handler = (req: HttpRequest) => {
-    const lastId = req.headers.get("last-event-id")?.value;
-    const startFrom = lastId ? Number.parseInt(lastId, 10) + 1 : 0;
+    const lastId = Number.parseInt(req.headers.get("last-event-id")?.value ?? "", 10);
+    const startFrom = Number.isNaN(lastId) ? 0 : lastId + 1;
 
     async function* events(): AsyncGenerator<SseEvent> {
         for (let i = startFrom; i < 100; i++) {


### PR DESCRIPTION
Add the @taxum/core/sse module with the SseEvent type and Sse response
class for streaming server-to-client events over HTTP, with automatic
SSE framing (multi-line data splitting, field validation) and optional
keep-alive comments to prevent proxy timeouts.

The event pipeline is composed of TransformStreams, so backpressure
and cancellation propagate in both modes: a slow client pauses the
event source instead of buffering unboundedly, client disconnects and
serialization errors cancel the source (running async generator
cleanup), and serialization failures are logged since they occur after
headers are sent and cannot produce an error response. The keep-alive
timer is refreshed per event and skips intervals while the consumer is
stalled.

Sse instances are single-use: converting twice or calling keepAlive()
after conversion throws, and the keep-alive interval is validated. No
connection header is set; connection management belongs to the server
layer and HTTP/2 forbids the header.

Includes a guide page covering usage, reconnection via Last-Event-ID,
keep-alive, cooperative shutdown via SHUTDOWN_SIGNAL, and resource
cleanup on client disconnect.