### PR TITLE
fix(core): close connections properly during graceful shutdown

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -48,10 +48,11 @@ export type ServeConfig = {
     catchCtrlC?: boolean;
 
     /**
-     * Maximum time (in milliseconds) to wait before returning.
+     * Maximum time (in milliseconds) to wait for open connections to close during shutdown.
      *
-     * This will `unref` the server once the timeout expired and return early. The server will still be open until your
-     * program exits.
+     * Once the timeout expires, all remaining connections are forcefully closed and their
+     * response body streams are cancelled. Without this, the server waits indefinitely for
+     * long-running responses (e.g. streams) to finish.
      */
     shutdownTimeout?: number;
 
@@ -91,22 +92,34 @@ export type ServeConfig = {
  * ```
  */
 export const serve = async (service: HttpService, config?: ServeConfig): Promise<void> => {
-    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        let httpRequests: HttpRequest;
+    let closing = false;
+
+    const writeResponse = async (response: HttpResponse, res: ServerResponse): Promise<void> => {
+        if (closing) {
+            // Tell keep-alive clients to stop reusing this connection; Node.js closes the
+            // socket once the response has finished.
+            response.headers.insert("connection", "close");
+        }
+
+        await response.write(res);
+    };
+
+    const respond = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+        let httpRequest: HttpRequest;
 
         try {
-            httpRequests = HttpRequest.fromIncomingMessage(req, config?.trustProxy ?? false);
+            httpRequest = HttpRequest.fromIncomingMessage(req, config?.trustProxy ?? false);
         } catch {
             const response = HttpResponse.builder()
                 .status(StatusCode.BAD_REQUEST)
                 .body("Malformed HTTP request");
-            await response.write(res);
+            await writeResponse(response, res);
             return;
         }
 
         try {
-            const response = await service.invoke(httpRequests);
-            await response.write(res);
+            const response = await service.invoke(httpRequest);
+            await writeResponse(response, res);
         } catch (error) {
             getLoggerProxy().error("Uncaught error in router", { error });
 
@@ -118,14 +131,22 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
                 // Noop
             }
         }
+    };
+
+    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+        await respond(req, res);
+
+        // Responses whose headers were already sent when shutdown began cannot carry a
+        // `connection: close` header, so their sockets must be torn down explicitly once the
+        // response has finished.
+        if (closing && !req.socket.destroyed) {
+            req.socket.destroySoon();
+        }
     });
 
     if (config?.unrefOnStart) {
         server.unref();
     }
-
-    const abortController = new AbortController();
-    let closing = false;
 
     const closeServer = (): void => {
         /* node:coverage ignore next 3 */
@@ -142,9 +163,13 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
         server.close();
 
         if (config?.shutdownTimeout) {
-            setTimeout(() => {
-                abortController.abort();
+            const forceCloseTimer = setTimeout(() => {
+                server.closeAllConnections();
             }, config.shutdownTimeout);
+
+            server.once("close", () => {
+                clearTimeout(forceCloseTimer);
+            });
         }
     };
 
@@ -171,10 +196,6 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
             );
 
             config?.onListen?.(address);
-        });
-
-        abortController.signal.addEventListener("abort", () => {
-            resolve();
         });
     });
 };

--- a/packages/core/test/server/index.test.ts
+++ b/packages/core/test/server/index.test.ts
@@ -1,12 +1,36 @@
 import assert from "node:assert/strict";
+import net from "node:net";
 import { afterEach, describe, it } from "node:test";
-import { HttpResponse, noContentResponse, TO_HTTP_RESPONSE } from "../../src/http/index.js";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+    Body,
+    HeaderMap,
+    HttpResponse,
+    noContentResponse,
+    StatusCode,
+    TO_HTTP_RESPONSE,
+} from "../../src/http/index.js";
 import { type ServeConfig, serve } from "../../src/server/index.js";
 import type { HttpService } from "../../src/service/index.js";
 
 const makeMockService = (f: () => Promise<HttpResponse> | HttpResponse): HttpService => ({
     invoke: f,
 });
+
+const withTimeout = async <T>(promise: Promise<T>, ms: number, message: string): Promise<T> => {
+    const timer = new AbortController();
+
+    try {
+        return await Promise.race([
+            promise,
+            delay(ms, undefined, { signal: timer.signal }).then(() => {
+                throw new Error(message);
+            }),
+        ]);
+    } finally {
+        timer.abort();
+    }
+};
 
 describe("server:index", () => {
     describe("serve", () => {
@@ -158,6 +182,221 @@ describe("server:index", () => {
             };
 
             await serve(service, config);
+        });
+
+        it("force-closes streaming connections at the shutdown deadline", async () => {
+            const encoder = new TextEncoder();
+
+            const { promise: streamCancellation, resolve: streamCancelled } =
+                Promise.withResolvers<void>();
+
+            async function* endlessChunks(): AsyncGenerator<Uint8Array> {
+                try {
+                    while (true) {
+                        yield encoder.encode("data: ping\n\n");
+                        await delay(20);
+                    }
+                } finally {
+                    streamCancelled();
+                }
+            }
+
+            const service = makeMockService(
+                () =>
+                    new HttpResponse(
+                        StatusCode.OK,
+                        new HeaderMap(),
+                        new Body(ReadableStream.from(endlessChunks())),
+                    ),
+            );
+
+            const controller = new AbortController();
+            let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+            const { promise: clientConnectionEnded, resolve: clientSawEnd } =
+                Promise.withResolvers<void>();
+
+            const config: ServeConfig = {
+                shutdownTimeout: 200,
+                abortSignal: controller.signal,
+                onListen: async ({ port }) => {
+                    const response = await fetch(`http://localhost:${port}`);
+                    reader = response.body?.getReader();
+                    await reader?.read();
+                    controller.abort();
+
+                    try {
+                        while (!((await reader?.read())?.done ?? true)) {
+                            // Drain until the server terminates the connection.
+                        }
+                    } catch {
+                        // An abrupt termination is fine as well.
+                    }
+
+                    clientSawEnd();
+                },
+            };
+
+            try {
+                await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+                await withTimeout(
+                    streamCancellation,
+                    1000,
+                    "body stream was not cancelled at the shutdown deadline",
+                );
+                await withTimeout(
+                    clientConnectionEnded,
+                    1000,
+                    "client connection was not terminated at the shutdown deadline",
+                );
+            } finally {
+                await reader?.cancel().catch(() => undefined);
+            }
+        });
+
+        it("marks in-flight responses with connection: close during shutdown", async () => {
+            const { promise: handlerStart, resolve: handlerStarted } =
+                Promise.withResolvers<void>();
+            const { promise: handlerRelease, resolve: releaseHandler } =
+                Promise.withResolvers<void>();
+
+            const service = makeMockService(async () => {
+                handlerStarted();
+                await handlerRelease;
+                return HttpResponse.builder().body("done");
+            });
+
+            const controller = new AbortController();
+            let socket: net.Socket | undefined;
+            let rawResponse = "";
+
+            const { promise: socketEnd, resolve: socketEnded } = Promise.withResolvers<void>();
+
+            const config: ServeConfig = {
+                abortSignal: controller.signal,
+                onListen: async ({ port }) => {
+                    socket = net.connect(port, "localhost");
+
+                    socket.on("data", (chunk) => {
+                        rawResponse += chunk.toString();
+                    });
+
+                    socket.on("end", () => {
+                        socketEnded();
+                    });
+
+                    socket.write("GET / HTTP/1.1\r\nhost: localhost\r\n\r\n");
+                    await handlerStart;
+                    controller.abort();
+                    releaseHandler();
+                },
+            };
+
+            try {
+                await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+                await withTimeout(
+                    socketEnd,
+                    1000,
+                    "socket was not closed after the in-flight response finished",
+                );
+
+                assert.match(rawResponse, /^connection: close$/im);
+            } finally {
+                socket?.destroy();
+            }
+        });
+
+        it("stops serving kept-alive sockets whose response headers predate shutdown", async () => {
+            const encoder = new TextEncoder();
+
+            const { promise: bodyRelease, resolve: releaseBody } = Promise.withResolvers<void>();
+
+            const service = makeMockService(
+                () =>
+                    new HttpResponse(
+                        StatusCode.OK,
+                        new HeaderMap(),
+                        new Body(
+                            new ReadableStream({
+                                start: async (streamController) => {
+                                    streamController.enqueue(encoder.encode("hello"));
+                                    await bodyRelease;
+                                    streamController.close();
+                                },
+                            }),
+                        ),
+                    ),
+            );
+
+            const controller = new AbortController();
+            let socket: net.Socket | undefined;
+            let responseData = "";
+            let firstResponseDone = false;
+            let dataAfterFirstResponse = false;
+
+            const { promise: socketEnd, resolve: socketEnded } = Promise.withResolvers<void>();
+            const { promise: firstChunk, resolve: firstChunkReceived } =
+                Promise.withResolvers<void>();
+            const { promise: firstResponse, resolve: firstResponseCompleted } =
+                Promise.withResolvers<void>();
+
+            const config: ServeConfig = {
+                abortSignal: controller.signal,
+                onListen: async ({ port }) => {
+                    socket = net.connect(port, "localhost");
+
+                    socket.on("error", () => {
+                        // The server may reset the socket while the second request is in flight.
+                    });
+
+                    socket.on("data", (chunk) => {
+                        if (firstResponseDone) {
+                            dataAfterFirstResponse = true;
+                            return;
+                        }
+
+                        responseData += chunk.toString();
+
+                        if (responseData.includes("hello")) {
+                            firstChunkReceived();
+                        }
+
+                        if (responseData.includes("\r\n0\r\n\r\n")) {
+                            firstResponseDone = true;
+                            firstResponseCompleted();
+                        }
+                    });
+
+                    socket.on("end", () => {
+                        socketEnded();
+                    });
+
+                    socket.write("GET / HTTP/1.1\r\nhost: localhost\r\n\r\n");
+                    await firstChunk;
+
+                    controller.abort();
+                    releaseBody();
+
+                    await firstResponse;
+                    socket.write("GET / HTTP/1.1\r\nhost: localhost\r\n\r\n");
+                },
+            };
+
+            try {
+                await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+                await withTimeout(
+                    socketEnd,
+                    1000,
+                    "socket was not closed after the in-flight response finished",
+                );
+
+                assert(
+                    !dataAfterFirstResponse,
+                    "second request on kept-alive socket should not be served during shutdown",
+                );
+            } finally {
+                socket?.destroy();
+            }
         });
     });
 });


### PR DESCRIPTION
- mark responses written during shutdown with connection: close so
  keep-alive clients stop reusing the connection
- destroy kept-alive sockets once their in-flight response finishes,
  closing the window where clients could sneak in further requests
- force-close all remaining connections when shutdownTimeout expires,
  cancelling their response body streams instead of leaving them open
- resolve serve() only once the server has actually closed, replacing
  the early-resolve hack that left sockets open past the timeout