### PR TITLE
fix(core): preserve connectInfo when middleware rebuilds requests

### DIFF
--- a/packages/core/src/middleware/decompression.ts
+++ b/packages/core/src/middleware/decompression.ts
@@ -1,7 +1,7 @@
 import { Transform } from "node:stream";
 import zlib from "node:zlib";
 import { Body, HttpResponse, StatusCode } from "../http/index.js";
-import { HttpRequest } from "../http/request.js";
+import type { HttpRequest } from "../http/request.js";
 import type { HttpLayer } from "../layer/index.js";
 import type { HttpService } from "../service/index.js";
 import { AcceptEncoding } from "./compression-utils.js";
@@ -177,5 +177,5 @@ const invokeWithStream = async (
     req.headers.remove("content-encoding");
     req.headers.remove("content-length");
 
-    return inner.invoke(new HttpRequest(req.head, new Body(stream)));
+    return inner.invoke(req.withBody(new Body(stream)));
 };

--- a/packages/core/src/middleware/limit.ts
+++ b/packages/core/src/middleware/limit.ts
@@ -1,4 +1,4 @@
-import { Body, HttpRequest, type HttpResponse, StatusCode } from "../http/index.js";
+import { Body, type HttpRequest, type HttpResponse, StatusCode } from "../http/index.js";
 import type { HttpLayer } from "../layer/index.js";
 import type { HttpService } from "../service/index.js";
 import { ClientError } from "../util/index.js";
@@ -73,7 +73,7 @@ class RequestBodyLimit implements HttpService {
         });
         const readable = new Body(req.body.readable.pipeThrough(limitedBody));
 
-        return this.inner.invoke(new HttpRequest(req.head, readable, req.connectInfo));
+        return this.inner.invoke(req.withBody(readable));
     }
 }
 

--- a/packages/core/test/middleware/decompression.test.ts
+++ b/packages/core/test/middleware/decompression.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { SocketAddress } from "node:net";
 import { PassThrough } from "node:stream";
 import consumers from "node:stream/consumers";
 import { describe, it } from "node:test";
@@ -40,6 +41,32 @@ describe("RequestDecompressionLayer", () => {
 
         assert.equal(res.status, StatusCode.OK);
         assert.equal(await consumers.text(res.body.readable), originalData);
+    });
+
+    it("preserves connectInfo when decompressing", async () => {
+        const connectInfo = new SocketAddress({ address: "192.0.2.1", family: "ipv4", port: 1234 });
+        let seenConnectInfo: SocketAddress | undefined;
+
+        const inner: HttpService = {
+            invoke: async (req: HttpRequest) => {
+                seenConnectInfo = req.connectInfo;
+                return HttpResponse.builder().body(null);
+            },
+        };
+
+        const layer = new RequestDecompressionLayer();
+        const service = layer.layer(inner);
+
+        const gzipStream = new PassThrough();
+        gzipStream.end(zlib.gzipSync(Buffer.from("hello")));
+
+        const req = HttpRequest.builder()
+            .header("content-encoding", "gzip")
+            .connectInfo(connectInfo)
+            .body(gzipStream);
+        await service.invoke(req);
+
+        assert.equal(seenConnectInfo, connectInfo);
     });
 
     it("decompresses deflate encoded request", async () => {

--- a/packages/core/test/middleware/limit.test.ts
+++ b/packages/core/test/middleware/limit.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { SocketAddress } from "node:net";
 import { Readable } from "node:stream";
 import consumers from "node:stream/consumers";
 import { describe, it } from "node:test";
@@ -25,6 +26,26 @@ describe("middleware:limit", () => {
         const res = await service.invoke(req);
 
         assert.equal(await consumers.text(res.body.readable), "ok");
+    });
+
+    it("preserves connectInfo when limiting the body", async () => {
+        const connectInfo = new SocketAddress({ address: "192.0.2.1", family: "ipv4", port: 1234 });
+        let seenConnectInfo: SocketAddress | undefined;
+
+        const inner: HttpService = {
+            invoke: async (req: HttpRequest) => {
+                seenConnectInfo = req.connectInfo;
+                return HttpResponse.builder().body(null);
+            },
+        };
+
+        const layer = new RequestBodyLimitLayer(10);
+        const service = layer.layer(inner);
+
+        const req = HttpRequest.builder().connectInfo(connectInfo).body("hello");
+        await service.invoke(req);
+
+        assert.equal(seenConnectInfo, connectInfo);
     });
 
     it("throws 413 immediately if content-length exceeds limit", async () => {


### PR DESCRIPTION
The decompression middleware rebuilt requests via the HttpRequest
constructor without passing connectInfo, silently resetting the peer
address to 0.0.0.0 for all downstream consumers (e.g. client-ip).

Route both decompression and limit through req.withBody() so request
reconstruction is confined to request.ts and always carries all
connection context.