### PR TITLE
feat(core): expose disconnect and shutdown signals to request handlers

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -8,9 +8,44 @@
 import assert from "node:assert";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
-import { HttpRequest, HttpResponse, StatusCode } from "../http/index.js";
+import { ExtensionKey, HttpRequest, HttpResponse, StatusCode } from "../http/index.js";
 import { getLoggerProxy } from "../logging/index.js";
 import type { HttpService } from "../service/index.js";
+
+/**
+ * Extension containing an {@link AbortSignal} which is aborted when the connection is closed
+ * before the response has finished, whether because the client disconnected or because the
+ * connection was forcefully closed when {@link ServeConfig.shutdownTimeout} expired.
+ *
+ * Once this signal aborts, nothing the handler produces can be delivered anymore, so any
+ * ongoing work for the response should be cancelled.
+ *
+ * Absent on requests which were not created by {@link serve}.
+ *
+ * @example
+ * ```ts
+ * import { extension } from "@taxum/core/extract";
+ * import { DISCONNECT_SIGNAL } from "@taxum/core/server";
+ *
+ * const handler = createExtractHandler(extension(DISCONNECT_SIGNAL))((signal) => {
+ *     // ...
+ * });
+ * ```
+ */
+export const DISCONNECT_SIGNAL = new ExtensionKey<AbortSignal>("Disconnect signal");
+
+/**
+ * Extension containing an {@link AbortSignal} which is aborted when the server begins its
+ * graceful shutdown.
+ *
+ * In contrast to {@link DISCONNECT_SIGNAL}, the connection is still writable when this signal
+ * aborts. Long-running responses (e.g. Server-Sent Event streams) should finish up promptly,
+ * possibly emitting a final message; otherwise they are forcefully terminated once the
+ * configured {@link ServeConfig.shutdownTimeout} expires.
+ *
+ * Absent on requests which were not created by {@link serve}.
+ */
+export const SHUTDOWN_SIGNAL = new ExtensionKey<AbortSignal>("Shutdown signal");
 
 /**
  * Configuration options for starting a server.
@@ -93,6 +128,7 @@ export type ServeConfig = {
  */
 export const serve = async (service: HttpService, config?: ServeConfig): Promise<void> => {
     let closing = false;
+    const shutdownController = new AbortController();
 
     const writeResponse = async (response: HttpResponse, res: ServerResponse): Promise<void> => {
         if (closing) {
@@ -116,6 +152,17 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
             await writeResponse(response, res);
             return;
         }
+
+        const disconnectController = new AbortController();
+
+        res.once("close", () => {
+            if (!res.writableFinished) {
+                disconnectController.abort();
+            }
+        });
+
+        httpRequest.extensions.insert(DISCONNECT_SIGNAL, disconnectController.signal);
+        httpRequest.extensions.insert(SHUTDOWN_SIGNAL, shutdownController.signal);
 
         try {
             const response = await service.invoke(httpRequest);
@@ -160,6 +207,7 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
         process.removeAllListeners("SIGTERM");
 
         closing = true;
+        shutdownController.abort();
         server.close();
 
         if (config?.shutdownTimeout) {

--- a/packages/core/test/server/index.test.ts
+++ b/packages/core/test/server/index.test.ts
@@ -5,15 +5,23 @@ import { setTimeout as delay } from "node:timers/promises";
 import {
     Body,
     HeaderMap,
+    type HttpRequest,
     HttpResponse,
     noContentResponse,
     StatusCode,
     TO_HTTP_RESPONSE,
 } from "../../src/http/index.js";
-import { type ServeConfig, serve } from "../../src/server/index.js";
+import {
+    DISCONNECT_SIGNAL,
+    type ServeConfig,
+    SHUTDOWN_SIGNAL,
+    serve,
+} from "../../src/server/index.js";
 import type { HttpService } from "../../src/service/index.js";
 
-const makeMockService = (f: () => Promise<HttpResponse> | HttpResponse): HttpService => ({
+const makeMockService = (
+    f: (req: HttpRequest) => Promise<HttpResponse> | HttpResponse,
+): HttpService => ({
     invoke: f,
 });
 
@@ -397,6 +405,188 @@ describe("server:index", () => {
             } finally {
                 socket?.destroy();
             }
+        });
+
+        it("aborts the disconnect signal when the client disconnects mid-response", async () => {
+            const encoder = new TextEncoder();
+            const { promise: disconnected, resolve: sawDisconnect } = Promise.withResolvers<void>();
+
+            const service = makeMockService((req) => {
+                const signal = req.extensions.get(DISCONNECT_SIGNAL);
+                assert(signal);
+                signal.addEventListener("abort", () => sawDisconnect());
+
+                async function* endlessChunks(): AsyncGenerator<Uint8Array> {
+                    while (true) {
+                        yield encoder.encode("data: ping\n\n");
+                        await delay(20);
+                    }
+                }
+
+                return new HttpResponse(
+                    StatusCode.OK,
+                    new HeaderMap(),
+                    new Body(ReadableStream.from(endlessChunks())),
+                );
+            });
+
+            const serverController = new AbortController();
+
+            const config: ServeConfig = {
+                abortSignal: serverController.signal,
+                onListen: async ({ port }) => {
+                    const fetchController = new AbortController();
+                    const response = await fetch(`http://localhost:${port}`, {
+                        signal: fetchController.signal,
+                    });
+                    await response.body?.getReader().read();
+                    fetchController.abort();
+
+                    await withTimeout(
+                        disconnected,
+                        1000,
+                        "disconnect signal was not aborted on client disconnect",
+                    ).finally(() => {
+                        serverController.abort();
+                    });
+                },
+            };
+
+            await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+            await disconnected;
+        });
+
+        it("aborts the disconnect signal when a connection is force-closed at the deadline", async () => {
+            const encoder = new TextEncoder();
+            const { promise: disconnected, resolve: sawDisconnect } = Promise.withResolvers<void>();
+
+            const service = makeMockService((req) => {
+                const signal = req.extensions.get(DISCONNECT_SIGNAL);
+                assert(signal);
+                signal.addEventListener("abort", () => sawDisconnect());
+
+                async function* endlessChunks(): AsyncGenerator<Uint8Array> {
+                    while (true) {
+                        yield encoder.encode("data: ping\n\n");
+                        await delay(20);
+                    }
+                }
+
+                return new HttpResponse(
+                    StatusCode.OK,
+                    new HeaderMap(),
+                    new Body(ReadableStream.from(endlessChunks())),
+                );
+            });
+
+            const controller = new AbortController();
+            let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+            const config: ServeConfig = {
+                shutdownTimeout: 200,
+                abortSignal: controller.signal,
+                onListen: async ({ port }) => {
+                    const response = await fetch(`http://localhost:${port}`);
+                    reader = response.body?.getReader();
+                    await reader?.read();
+                    controller.abort();
+                },
+            };
+
+            try {
+                await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+                await withTimeout(
+                    disconnected,
+                    1000,
+                    "disconnect signal was not aborted on force-close",
+                );
+            } finally {
+                await reader?.cancel().catch(() => undefined);
+            }
+        });
+
+        it("does not abort the disconnect signal when the response completes normally", async () => {
+            let disconnectSignal: AbortSignal | undefined;
+
+            const service = makeMockService((req) => {
+                disconnectSignal = req.extensions.get(DISCONNECT_SIGNAL);
+                return HttpResponse.builder().body("hello");
+            });
+
+            const controller = new AbortController();
+
+            const config: ServeConfig = {
+                abortSignal: controller.signal,
+                onListen: async ({ port }) => {
+                    const response = await fetch(`http://localhost:${port}`);
+                    await response.text();
+                    controller.abort();
+                },
+            };
+
+            await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+
+            assert(disconnectSignal);
+            assert(!disconnectSignal.aborted, "disconnect signal must not abort on completion");
+        });
+
+        it("allows streaming responses to end cooperatively via the shutdown signal", async () => {
+            const encoder = new TextEncoder();
+            let clientBody = "";
+
+            const service = makeMockService((req) => {
+                const shutdownSignal = req.extensions.get(SHUTDOWN_SIGNAL);
+                assert(shutdownSignal);
+
+                async function* events(signal: AbortSignal): AsyncGenerator<Uint8Array> {
+                    while (!signal.aborted) {
+                        yield encoder.encode("data: ping\n\n");
+                        await delay(20);
+                    }
+
+                    yield encoder.encode("data: bye\n\n");
+                }
+
+                return new HttpResponse(
+                    StatusCode.OK,
+                    new HeaderMap(),
+                    new Body(ReadableStream.from(events(shutdownSignal))),
+                );
+            });
+
+            const controller = new AbortController();
+            const { promise: clientDone, resolve: clientFinished } = Promise.withResolvers<void>();
+
+            const config: ServeConfig = {
+                abortSignal: controller.signal,
+                onListen: async ({ port }) => {
+                    const response = await fetch(`http://localhost:${port}`);
+                    const reader = response.body?.getReader();
+                    assert(reader);
+                    await reader.read();
+                    controller.abort();
+
+                    const decoder = new TextDecoder();
+
+                    while (true) {
+                        const { done, value } = await reader.read();
+
+                        if (done) {
+                            break;
+                        }
+
+                        clientBody += decoder.decode(value);
+                    }
+
+                    clientFinished();
+                },
+            };
+
+            // No shutdownTimeout: shutdown completes through cooperation alone.
+            await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+            await withTimeout(clientDone, 1000, "client did not receive the end of the stream");
+
+            assert.match(clientBody, /data: bye/);
         });
     });
 });

--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -100,6 +100,10 @@ export default withMermaid(
                                 link: "/guide/core-concepts/logging",
                             },
                             {
+                                text: "Graceful Shutdown",
+                                link: "/guide/core-concepts/graceful-shutdown",
+                            },
+                            {
                                 text: "Testing",
                                 link: "/guide/core-concepts/testing",
                             },

--- a/packages/docs/src/guide/core-concepts/graceful-shutdown.md
+++ b/packages/docs/src/guide/core-concepts/graceful-shutdown.md
@@ -1,0 +1,90 @@
+---
+description: Shutting down a Taxum server without dropping in-flight requests.
+---
+
+# Graceful Shutdown
+
+`serve()` shuts down gracefully when the configured `abortSignal` aborts or, with `catchCtrlC` enabled, when the
+process receives `SIGINT`, `SIGQUIT` or `SIGTERM`.
+
+```ts
+import { serve } from "@taxum/core/server";
+
+await serve(router, {
+    port: 8080,
+    catchCtrlC: true,
+    shutdownTimeout: 5000,
+});
+```
+
+Once shutdown begins:
+
+1. The server stops accepting new connections, and idle keep-alive connections are closed immediately.
+2. In-flight requests complete normally. Their responses are marked `connection: close`, and their sockets are closed
+   as soon as the response has finished, so clients cannot keep reusing them.
+3. `serve()` resolves once the last connection has closed.
+
+## Shutdown timeout
+
+Without a `shutdownTimeout`, the server waits indefinitely for in-flight requests. A single long-running response, such
+as an endless stream, keeps the process alive until an orchestrator kills it.
+
+With `shutdownTimeout` set, all remaining connections are forcefully closed once the timeout expires. Their response
+body streams are cancelled, so a streaming body backed by an async generator has its `finally` blocks run.
+
+You should always configure a `shutdownTimeout` in production. Pick a value below the grace period of your process
+supervisor (Kubernetes gives 30 seconds by default), so Taxum closes connections cleanly instead of dying mid-write.
+
+## Cooperative shutdown
+
+Handlers producing long-running responses shouldn't wait for the forceful close. The `SHUTDOWN_SIGNAL` extension
+contains an `AbortSignal` which aborts the moment shutdown begins, while the connection is still writable. This gives
+streaming responses a chance to send a final message and end cleanly:
+
+```ts
+import { setTimeout as delay } from "node:timers/promises";
+import { extension } from "@taxum/core/extract";
+import { createExtractHandler } from "@taxum/core/routing";
+import { SHUTDOWN_SIGNAL } from "@taxum/core/server";
+
+const streamHandler = createExtractHandler(extension(SHUTDOWN_SIGNAL, true)).handler(
+    (shutdownSignal) => {
+        async function* events(): AsyncGenerator<string> {
+            while (!shutdownSignal.aborted) {
+                yield "tick\n";
+                await delay(1000);
+            }
+
+            yield "server is shutting down, goodbye\n";
+        }
+
+        return ReadableStream.from(events());
+    },
+);
+```
+
+When every response ends cooperatively, shutdown completes without waiting for the timeout at all.
+
+## Disconnect signal
+
+The related `DISCONNECT_SIGNAL` extension aborts when the connection is closed before the response has finished,
+whether because the client disconnected or because the connection was forcefully closed at the shutdown timeout.
+Either way nothing the handler produces can be delivered anymore, so use it to cancel work whose result no one will
+receive:
+
+```ts
+import { extension } from "@taxum/core/extract";
+import { jsonResponse } from "@taxum/core/http";
+import { createExtractHandler } from "@taxum/core/routing";
+import { DISCONNECT_SIGNAL } from "@taxum/core/server";
+
+const reportHandler = createExtractHandler(extension(DISCONNECT_SIGNAL, true)).handler(
+    async (disconnectSignal) => {
+        const report = await generateExpensiveReport({ signal: disconnectSignal });
+        return jsonResponse(report);
+    },
+);
+```
+
+Both extensions are only present on requests created by `serve()`. Requests built manually, e.g. in tests, don't carry
+them, so the extractors return `undefined` unless the `required` flag is set.


### PR DESCRIPTION
serve() now inserts two extensions into every request it handles:

- SHUTDOWN_SIGNAL aborts when graceful shutdown begins, while the
  connection is still writable. Streaming responses can finish up
  cooperatively (e.g. emit a final message) instead of being
  forcefully closed at the shutdownTimeout deadline.
- DISCONNECT_SIGNAL aborts when the connection closes before the
  response has finished, whether through client disconnect or the
  forceful close at the deadline. Handlers can use it to cancel work
  whose result can no longer be delivered.

Also adds a graceful shutdown guide page documenting the shutdown
sequence and both signals.