### PR TITLE
feat(core): store connect info as request extension

### DIFF
--- a/packages/core/src/http/request.ts
+++ b/packages/core/src/http/request.ts
@@ -2,9 +2,22 @@ import type { IncomingMessage } from "node:http";
 import { SocketAddress } from "node:net";
 import type util from "node:util";
 import { Body, type BodyLike } from "./body.js";
-import { type ExtensionKey, Extensions } from "./extensions.js";
+import { ExtensionKey, Extensions } from "./extensions.js";
 import { HeaderMap, type HeaderValueLike } from "./headers.js";
 import { Method } from "./method.js";
+
+/**
+ * Extension containing the {@link SocketAddress} of the connection a request was received on.
+ *
+ * Inserted by {@link HttpRequest.fromIncomingMessage}. Absent on requests without an underlying
+ * connection, e.g. requests built manually in tests, unless inserted explicitly.
+ */
+export const CONNECT_INFO = new ExtensionKey<SocketAddress>("Connect info");
+
+const FALLBACK_CONNECT_INFO = new SocketAddress({
+    address: "0.0.0.0",
+    family: "ipv4",
+});
 
 /**
  * Represents the components of an HTTP request, encapsulating method, URI,
@@ -95,20 +108,33 @@ export class Parts {
 export class HttpRequest {
     public readonly head: Parts;
     public readonly body: Body;
-    public readonly connectInfo: SocketAddress;
 
     /**
      * Creates a new {@link HttpRequest}.
+     *
+     * @param connectInfo - stored as {@link CONNECT_INFO} extension, overriding any present
+     *                      value. Deprecated; insert the extension directly instead.
      */
     public constructor(head: Parts, body: Body, connectInfo?: SocketAddress) {
         this.head = head;
         this.body = body;
-        this.connectInfo =
-            connectInfo ??
-            new SocketAddress({
-                address: "0.0.0.0",
-                family: "ipv4",
-            });
+
+        if (connectInfo !== undefined) {
+            head.extensions.insert(CONNECT_INFO, connectInfo);
+        }
+    }
+
+    /**
+     * The {@link SocketAddress} of the connection the request was received on.
+     *
+     * Returns a `0.0.0.0` placeholder when no connect info is present.
+     *
+     * @deprecated Use the {@link CONNECT_INFO} extension instead, which is absent rather than
+     *             a placeholder when a request has no underlying connection. This getter will
+     *             be removed in the next major version.
+     */
+    public get connectInfo(): SocketAddress {
+        return this.extensions.get(CONNECT_INFO) ?? FALLBACK_CONNECT_INFO;
     }
 
     /**
@@ -125,15 +151,18 @@ export class HttpRequest {
      *      parameter.
      */
     public static fromIncomingMessage(message: IncomingMessage, trustProxy: boolean): HttpRequest {
+        const { remoteAddress, remoteFamily, remotePort } = message.socket;
+
         return new HttpRequest(
             Parts.fromIncomingMessage(message, trustProxy),
             Body.from(message),
-            new SocketAddress({
-                address:
-                    message.socket.remoteAddress === "" ? "0.0.0.0" : message.socket.remoteAddress,
-                family: message.socket.remoteFamily === "IPv6" ? "ipv6" : "ipv4",
-                port: message.socket.remotePort,
-            }),
+            remoteAddress !== undefined && remoteAddress !== ""
+                ? new SocketAddress({
+                      address: remoteAddress,
+                      family: remoteFamily === "IPv6" ? "ipv6" : "ipv4",
+                      port: remotePort,
+                  })
+                : undefined,
         );
     }
 
@@ -141,14 +170,14 @@ export class HttpRequest {
      * Creates a new {@link HttpRequest} with the provided body.
      */
     public withBody(body: Body): HttpRequest {
-        return new HttpRequest(this.head, body, this.connectInfo);
+        return new HttpRequest(this.head, body);
     }
 
     /**
      * Creates a new {@link HttpRequest} with the provided URI.
      */
     public withUri(uri: URL): HttpRequest {
-        return new HttpRequest(this.head.withUri(uri), this.body, this.connectInfo);
+        return new HttpRequest(this.head.withUri(uri), this.body);
     }
 
     public get method(): Method {
@@ -250,6 +279,10 @@ export class HttpRequestBuilder {
         return this;
     }
 
+    /**
+     * @deprecated Use `extension(CONNECT_INFO, connectInfo)` instead. This method will be
+     *             removed in the next major version.
+     */
     public connectInfo(connectInfo: SocketAddress): this {
         this.connectInfo_ = connectInfo;
         return this;

--- a/packages/core/src/middleware/client-ip.ts
+++ b/packages/core/src/middleware/client-ip.ts
@@ -1,5 +1,5 @@
 import { isIP } from "node:net";
-import { ExtensionKey, type HttpRequest, type HttpResponse } from "../http/index.js";
+import { CONNECT_INFO, ExtensionKey, type HttpRequest, type HttpResponse } from "../http/index.js";
 import type { HttpLayer } from "../layer/index.js";
 import type { HttpService } from "../service/index.js";
 
@@ -53,15 +53,25 @@ class SetClientIp implements HttpService {
     }
 
     public async invoke(req: HttpRequest): Promise<HttpResponse> {
+        const connectInfo = req.extensions.get(CONNECT_INFO);
+
+        if (connectInfo === undefined) {
+            throw new Error(
+                "SetClientIp requires connect info. The CONNECT_INFO extension is inserted by " +
+                    "HttpRequest.fromIncomingMessage(); when building requests manually, insert " +
+                    "the extension yourself.",
+            );
+        }
+
         if (!this.trustProxy) {
-            req.extensions.insert(CLIENT_IP, req.connectInfo.address);
+            req.extensions.insert(CLIENT_IP, connectInfo.address);
             return this.inner.invoke(req);
         }
 
         const forwardedFor = req.headers.get("x-forwarded-for");
 
         if (!forwardedFor) {
-            req.extensions.insert(CLIENT_IP, req.connectInfo.address);
+            req.extensions.insert(CLIENT_IP, connectInfo.address);
             return this.inner.invoke(req);
         }
 
@@ -71,7 +81,7 @@ class SetClientIp implements HttpService {
             .filter((ip) => isIP(ip) !== 0);
 
         if (ips.length === 0) {
-            req.extensions.insert(CLIENT_IP, req.connectInfo.address);
+            req.extensions.insert(CLIENT_IP, connectInfo.address);
             return this.inner.invoke(req);
         }
 

--- a/packages/core/test/http/request.test.ts
+++ b/packages/core/test/http/request.test.ts
@@ -5,6 +5,7 @@ import type { TLSSocket } from "node:tls";
 import util from "node:util";
 import {
     Body,
+    CONNECT_INFO,
     ExtensionKey,
     Extensions,
     HeaderMap,
@@ -157,6 +158,74 @@ describe("http:request", () => {
             assert.equal(req.method.value, "GET");
             assert.equal(req.uri.host, "example.com");
             assert.equal(req.version, "1.1");
+        });
+
+        it("stores connectInfo as CONNECT_INFO extension", () => {
+            const parts = new Parts(Method.GET, new URL("http://a"), "1.1", new HeaderMap());
+            const req = new HttpRequest(
+                parts,
+                Body.from(""),
+                SocketAddress.parse("127.0.0.1:8080"),
+            );
+
+            assert.equal(req.extensions.get(CONNECT_INFO)?.address, "127.0.0.1");
+            assert.equal(req.extensions.get(CONNECT_INFO)?.port, 8080);
+        });
+
+        it("lets constructor connectInfo override an existing CONNECT_INFO extension", () => {
+            const extensions = new Extensions();
+            const existing = SocketAddress.parse("10.0.0.1:1234");
+            assert(existing);
+            extensions.insert(CONNECT_INFO, existing);
+
+            const parts = new Parts(
+                Method.GET,
+                new URL("http://a"),
+                "1.1",
+                new HeaderMap(),
+                extensions,
+            );
+            const req = new HttpRequest(
+                parts,
+                Body.from(""),
+                SocketAddress.parse("127.0.0.1:8080"),
+            );
+
+            assert.equal(req.extensions.get(CONNECT_INFO)?.address, "127.0.0.1");
+        });
+
+        it("preserves CONNECT_INFO through withBody and withUri", () => {
+            const parts = new Parts(Method.GET, new URL("http://a"), "1.1", new HeaderMap());
+            const req = new HttpRequest(
+                parts,
+                Body.from(""),
+                SocketAddress.parse("127.0.0.1:8080"),
+            );
+
+            const rebuilt = req.withBody(Body.from("x")).withUri(new URL("http://b"));
+
+            assert.equal(rebuilt.extensions.get(CONNECT_INFO)?.address, "127.0.0.1");
+        });
+
+        it("fromIncomingMessage inserts CONNECT_INFO from the socket", () => {
+            const message = createIncomingMessage({ headers: { host: "example.com" } });
+            Object.defineProperty(message.socket, "remoteAddress", { value: "10.1.2.3" });
+            Object.defineProperty(message.socket, "remoteFamily", { value: "IPv4" });
+            Object.defineProperty(message.socket, "remotePort", { value: 54321 });
+
+            const req = HttpRequest.fromIncomingMessage(message, false);
+
+            assert.equal(req.extensions.get(CONNECT_INFO)?.address, "10.1.2.3");
+            assert.equal(req.extensions.get(CONNECT_INFO)?.port, 54321);
+        });
+
+        it("fromIncomingMessage omits CONNECT_INFO when the socket has no remote address", () => {
+            const message = createIncomingMessage({ headers: { host: "example.com" } });
+
+            const req = HttpRequest.fromIncomingMessage(message, false);
+
+            assert.equal(req.extensions.get(CONNECT_INFO), undefined);
+            assert.equal(req.connectInfo.address, "0.0.0.0");
         });
 
         it("accessor getters return correct properties", () => {

--- a/packages/core/test/middleware/client-ip.test.ts
+++ b/packages/core/test/middleware/client-ip.test.ts
@@ -7,6 +7,19 @@ import { CLIENT_IP, SetClientIpLayer } from "../../src/middleware/client-ip.js";
 describe("middleware/client-ip", () => {
     const dummyResponse = HttpResponse.builder().body(null);
 
+    it("throws when connect info is absent", async () => {
+        const innerService = {
+            invoke: async () => dummyResponse,
+        };
+
+        const layer = new SetClientIpLayer(false);
+        const service = layer.layer(innerService);
+
+        const req = HttpRequest.builder().body(null);
+
+        await assert.rejects(async () => service.invoke(req), /requires connect info/);
+    });
+
     it("inserts connectInfo.address as client IP when trustProxy is false", async () => {
         const connectInfo = new SocketAddress({ address: "192.168.1.100" });
         const innerService = {

--- a/packages/docs/src/guide/middleware/client-ip.md
+++ b/packages/docs/src/guide/middleware/client-ip.md
@@ -24,7 +24,8 @@ const router = new Router()
 
 ## How It Works
 
-1. If `trustProxy` is **false** (default), the layer uses the direct remote address from the request.
+1. If `trustProxy` is **false** (default), the layer uses the connection's remote address from the `CONNECT_INFO`
+   extension.
 2. If `trustProxy` is **true**, the layer checks the `X-Forwarded-For` header and returns the first valid IP.
 3. If no valid proxy header is found, the remote address is used as a fallback.
 
@@ -34,6 +35,18 @@ const router = new Router()
 - Should be applied **after** any rate-limiting or logging layers that rely on the client IP.
 - If behind multiple proxies, make sure your trusted proxy chain is properly configured, otherwise spoofed
   `X-Forwarded-For` headers could be used.
+- The layer requires the `CONNECT_INFO` extension and throws when it is missing. It is present on all requests
+  handled through `serve()` or created via `HttpRequest.fromIncomingMessage()`. When testing routes behind this
+  layer with manually built requests, insert it yourself:
+
+```ts
+import { SocketAddress } from "node:net";
+import { CONNECT_INFO, HttpRequest } from "@taxum/core/http";
+
+const req = HttpRequest.builder()
+    .extension(CONNECT_INFO, new SocketAddress({ address: "192.0.2.1", family: "ipv4" }))
+    .body(null);
+```
 
 ## Layer Ordering
 


### PR DESCRIPTION
The new CONNECT_INFO extension is now the single storage for the
connection's socket address, following the same pattern as the
disconnect and shutdown signals. Extensions live on the request head,
so connect info now survives request reconstruction structurally
instead of relying on manual threading.

The legacy surfaces are deprecated but remain functional views over
the extension: the constructor param inserts it, the connectInfo
getter reads it (falling back to the 0.0.0.0 placeholder), and the
builder method feeds the param path. They will be removed in the next
major version.

fromIncomingMessage no longer fabricates a 0.0.0.0 address when the
socket has no remote address; the extension is simply absent.

SetClientIp now reads the extension and throws a descriptive error
when connect info is missing instead of silently reporting 0.0.0.0 as
the client IP.