### PR TITLE
fix(core): cancel discarded response bodies for HEAD and CONNECT

### DIFF
--- a/packages/core/src/routing/route.ts
+++ b/packages/core/src/routing/route.ts
@@ -49,19 +49,34 @@ export class Route implements HttpService {
                 res.body.sizeHint.lower !== 0
             ) {
                 getLoggerProxy().error("response to CONNECT with nonempty body");
-                res.body = Body.from(null);
+                discardBody(res);
             }
         } else if (topLevel) {
             setContentLength(res.headers, res.body.sizeHint);
 
             if (req.method.equals(Method.HEAD)) {
-                res.body = Body.from(null);
+                discardBody(res);
             }
         }
 
         return res;
     }
 }
+
+/**
+ * Replaces the response body with an empty one, cancelling the discarded body's stream.
+ *
+ * Cancellation releases the resources held by streaming bodies (e.g. runs an async generator's
+ * `finally` blocks), which JavaScript, unlike languages with destructors, doesn't do when the
+ * body is simply dropped.
+ */
+const discardBody = (res: HttpResponse): void => {
+    res.body.readable.cancel().catch(() => {
+        // Errors from a discarded body are of no interest.
+    });
+
+    res.body = Body.from(null);
+};
 
 const setContentLength = (headers: HeaderMap, sizeHint: SizeHint): void => {
     if (headers.containsKey("content-length")) {

--- a/packages/core/test/routing/route.test.ts
+++ b/packages/core/test/routing/route.test.ts
@@ -1,9 +1,33 @@
 import assert from "node:assert/strict";
 import consumers from "node:stream/consumers";
 import { describe, it } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { HttpRequest, HttpResponse, StatusCode } from "../../src/http/index.js";
 import type { Handler } from "../../src/routing/index.js";
 import { Route } from "../../src/routing/route.js";
+
+const withTimeout = async (promise: Promise<void>, ms: number, message: string): Promise<void> =>
+    Promise.race([
+        promise,
+        delay(ms).then(() => {
+            throw new Error(message);
+        }),
+    ]);
+
+const makeEndlessBody = (): { stream: ReadableStream<Uint8Array>; cancellation: Promise<void> } => {
+    const { promise: cancellation, resolve: cancelled } = Promise.withResolvers<void>();
+
+    const stream = new ReadableStream<Uint8Array>({
+        pull: (controller) => {
+            controller.enqueue(new TextEncoder().encode("data"));
+        },
+        cancel: () => {
+            cancelled();
+        },
+    });
+
+    return { stream, cancellation };
+};
 
 describe("routing:route", () => {
     const routeFrom = (handler: Handler): Route => {
@@ -81,5 +105,35 @@ describe("routing:route", () => {
         const res = await route.invoke(req);
 
         assert.equal(await consumers.text(res.body.readable), "");
+    });
+
+    it("cancels the discarded streaming body for HEAD requests", async () => {
+        const { stream, cancellation } = makeEndlessBody();
+        const route = new Route({
+            invoke: async () => HttpResponse.builder().body(stream),
+        });
+
+        const req = HttpRequest.builder().method("HEAD").body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(await consumers.text(res.body.readable), "");
+        await withTimeout(cancellation, 500, "discarded HEAD body was not cancelled");
+    });
+
+    it("cancels the discarded streaming body for CONNECT responses", async (t) => {
+        t.mock.method(console, "error", () => {
+            // Suppress console.error
+        });
+
+        const { stream, cancellation } = makeEndlessBody();
+        const route = new Route({
+            invoke: async () => HttpResponse.builder().header("content-length", "999").body(stream),
+        });
+
+        const req = HttpRequest.builder().method("CONNECT").body(null);
+        const res = await route.invoke(req);
+
+        assert.equal(await consumers.text(res.body.readable), "");
+        await withTimeout(cancellation, 500, "discarded CONNECT body was not cancelled");
     });
 });

--- a/packages/core/test/routing/route.test.ts
+++ b/packages/core/test/routing/route.test.ts
@@ -120,6 +120,28 @@ describe("routing:route", () => {
         await withTimeout(cancellation, 500, "discarded HEAD body was not cancelled");
     });
 
+    it("ignores cancellation errors from the discarded body", async () => {
+        const stream = new ReadableStream<Uint8Array>({
+            pull: (controller) => {
+                controller.enqueue(new TextEncoder().encode("data"));
+            },
+            cancel: () => {
+                throw new Error("cancel failed");
+            },
+        });
+
+        const route = new Route({
+            invoke: async () => HttpResponse.builder().body(stream),
+        });
+
+        const req = HttpRequest.builder().method("HEAD").body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(await consumers.text(res.body.readable), "");
+        // An unhandled rejection from the discarded body would fail this test.
+        await delay(10);
+    });
+
     it("cancels the discarded streaming body for CONNECT responses", async (t) => {
         t.mock.method(console, "error", () => {
             // Suppress console.error


### PR DESCRIPTION
Route replaced response bodies with an empty one for HEAD requests and
nonempty CONNECT responses without cancelling the discarded body's
stream. Unlike in Rust, where dropping a body releases its resources
via Drop, dropping a ReadableStream reference in JavaScript does
nothing: a streaming body kept producing into an orphaned queue, its
cleanup (e.g. an async generator's finally blocks) never ran, and any
timers it held kept the process alive. A HEAD health probe against a
streaming route leaked those resources on every request.