### PR TITLE
ci: allow deps, deps-dev, and docs scopes in PR titles

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -24,6 +24,9 @@ jobs:
             fs
             jwt
             examples
+            docs
+            deps
+            deps-dev
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"


### PR DESCRIPTION
Dependabot titles its PRs build(deps): / build(deps-dev): based on
conventional-commit auto-detection, and both scopes were rejected by
the PR title allowlist. The docs scope is already used in commit
history but was missing as well.