### PR TITLE
fix(core): preserve multiple values per key in HeaderMap.extend

### DIFF
--- a/packages/core/src/http/headers.ts
+++ b/packages/core/src/http/headers.ts
@@ -215,13 +215,26 @@ export class HeaderMap implements ToHttpResponseParts {
     }
 
     /**
-     * Extends the map by inserting key-value pairs from the given iterable.
+     * Extends the map with the key-value pairs from the given iterable.
      *
-     * Values in the iterable will overwrite existing values for the same key.
+     * The first value seen for a given key replaces any existing values for
+     * that key; further values for the same key are appended. This mirrors
+     * Rust's `http::HeaderMap::extend`, so merging a source that holds multiple
+     * values under one key (such as several `Set-Cookie` headers) preserves all
+     * of them.
      */
     public extend(items: Iterable<HeaderEntry>): void {
-        for (const item of items) {
-            this.insert(item[0], item[1]);
+        const replaced = new Set<string>();
+
+        for (const [key, value] of items) {
+            const lowercaseKey = key.toLowerCase();
+
+            if (replaced.has(lowercaseKey)) {
+                this.append(key, value);
+            } else {
+                this.insert(key, value);
+                replaced.add(lowercaseKey);
+            }
         }
     }
 

--- a/packages/core/test/http/headers.test.ts
+++ b/packages/core/test/http/headers.test.ts
@@ -127,6 +127,31 @@ describe("http:headers", () => {
             assert.deepEqual(map.getAll("hello"), [new HeaderValue("world")]);
         });
 
+        it("extend preserves multiple values for the same key", () => {
+            const map = new HeaderMap();
+            map.extend([
+                ["set-cookie", new HeaderValue("a=1")],
+                ["set-cookie", new HeaderValue("b=2")],
+            ]);
+            assert.deepEqual(map.getAll("set-cookie"), [
+                new HeaderValue("a=1"),
+                new HeaderValue("b=2"),
+            ]);
+        });
+
+        it("extend replaces an existing key with the first value then appends the rest", () => {
+            const map = new HeaderMap();
+            map.insert("set-cookie", "stale=1");
+            map.extend([
+                ["set-cookie", new HeaderValue("a=1")],
+                ["set-cookie", new HeaderValue("b=2")],
+            ]);
+            assert.deepEqual(map.getAll("set-cookie"), [
+                new HeaderValue("a=1"),
+                new HeaderValue("b=2"),
+            ]);
+        });
+
         it("toJSON includes all header values", () => {
             const map = HeaderMap.from([
                 ["x-a", "1"],


### PR DESCRIPTION
## Summary
- `HeaderMap.extend` called `insert` for every entry, and `insert` replaces all values for a key, so merging a source holding multiple values under one key (several `Set-Cookie`, `Vary`, `WWW-Authenticate`) collapsed to only the last value.
- It now mirrors `http::HeaderMap::extend`: the first value seen for a key replaces any existing values, and subsequent same-key values are appended.
- Reached via `HttpResponseBuilder.headers()`, the tuple form of `HttpResponse.from()`, and using a `HeaderMap` as a response part.