### PR TITLE
fix(cookie): harden cookie parsing, signing, and encoding

### DIFF
--- a/packages/cookie/src/cookie.ts
+++ b/packages/cookie/src/cookie.ts
@@ -37,6 +37,43 @@ export type CookieOptions = {
 };
 
 /**
+ * Decodes a percent-encoded cookie component.
+ *
+ * A component that fails to decode (an invalid percent sequence) is returned
+ * unchanged rather than throwing, so a single malformed cookie does not fail the
+ * whole request. This is more conservative than a per-escape lossy decode: the
+ * entire component is left raw when any escape is invalid, not just the bad
+ * bytes.
+ */
+const decodeComponent = (value: string): string => {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+};
+
+/**
+ * Rejects a `Path` or `Domain` attribute value that could break out of the
+ * `Set-Cookie` line.
+ *
+ * These attributes are written verbatim, so a control character or a ";"
+ * would allow header or attribute injection. Name and value are safe because
+ * they are percent-encoded on {@link Cookie.encode}.
+ */
+const assertValidAttribute = (field: "path" | "domain", value: string): void => {
+    for (const character of value) {
+        const code = character.charCodeAt(0);
+
+        if (code <= 0x1f || code === 0x7f || character === ";") {
+            throw new TypeError(
+                `Cookie ${field} must not contain control characters or a ";" separator`,
+            );
+        }
+    }
+};
+
+/**
  * Represents an HTTP cookie.
  *
  * @example
@@ -64,6 +101,14 @@ export class Cookie {
      * You can additionally supply any of the standard cookie options.
      */
     public constructor(name: string, value = "", options?: CookieOptions) {
+        if (options?.path !== undefined) {
+            assertValidAttribute("path", options.path);
+        }
+
+        if (options?.domain !== undefined) {
+            assertValidAttribute("domain", options.domain);
+        }
+
         this.name = name;
         this.value = value;
         this.expires = options?.expires;
@@ -80,20 +125,20 @@ export class Cookie {
      * Parses a cookie string into a `Cookie` header.
      */
     public static parse(cookie: string): Cookie | null {
-        const nameValue = cookie.split("=", 2);
+        const separatorIndex = cookie.indexOf("=");
 
-        if (nameValue.length !== 2) {
+        if (separatorIndex === -1) {
             return null;
         }
 
-        const name = nameValue[0].trim();
-        const value = nameValue[1].trim();
+        const name = cookie.slice(0, separatorIndex).trim();
+        const value = cookie.slice(separatorIndex + 1).trim();
 
         if (name.length === 0) {
             return null;
         }
 
-        return new Cookie(decodeURIComponent(name), decodeURIComponent(value));
+        return new Cookie(decodeComponent(name), decodeComponent(value));
     }
 
     /**
@@ -172,7 +217,7 @@ export class Cookie {
                     unit: "seconds" as const,
                     relativeTo: Temporal.Now.zonedDateTimeISO(),
                 };
-                parameters.push(`Max-Age=${Math.max(0, this.maxAge.total(totalOf))}`);
+                parameters.push(`Max-Age=${Math.max(0, Math.floor(this.maxAge.total(totalOf)))}`);
             }
         }
 

--- a/packages/cookie/src/signed.ts
+++ b/packages/cookie/src/signed.ts
@@ -1,4 +1,4 @@
-import { type BinaryLike, createHmac, type KeyObject } from "node:crypto";
+import { type BinaryLike, createHmac, type KeyObject, timingSafeEqual } from "node:crypto";
 import type { Cookie } from "./cookie.js";
 import type { CookieJar } from "./jar.js";
 
@@ -84,6 +84,10 @@ export class SignedJar {
         hmac.update(value);
         const actualDigest = hmac.digest();
 
-        return digest.equals(actualDigest) ? value : null;
+        if (digest.length !== actualDigest.length) {
+            return null;
+        }
+
+        return timingSafeEqual(digest, actualDigest) ? value : null;
     }
 }

--- a/packages/cookie/test/cookie.test.ts
+++ b/packages/cookie/test/cookie.test.ts
@@ -37,6 +37,17 @@ describe("cookie", () => {
             const cookie = new Cookie("empty");
             assert.equal(cookie.value, "");
         });
+
+        it("rejects control characters in the path", () => {
+            assert.throws(() => new Cookie("name", "value", { path: "/a\r\nb" }), TypeError);
+        });
+
+        it("rejects a ';' separator in the domain", () => {
+            assert.throws(
+                () => new Cookie("name", "value", { domain: "evil.com; Path=/" }),
+                TypeError,
+            );
+        });
     });
 
     describe("parse()", () => {
@@ -60,6 +71,19 @@ describe("cookie", () => {
 
         it("returns null if name is empty", () => {
             assert.equal(Cookie.parse("=value"), null);
+        });
+
+        it("keeps '=' characters in the value", () => {
+            const parsed = Cookie.parse("token=a=b=c");
+            assert(parsed);
+            assert.equal(parsed.name, "token");
+            assert.equal(parsed.value, "a=b=c");
+        });
+
+        it("passes through malformed percent-encoding instead of throwing", () => {
+            const parsed = Cookie.parse("foo=%");
+            assert(parsed);
+            assert.equal(parsed.value, "%");
         });
     });
 
@@ -168,6 +192,11 @@ describe("cookie", () => {
             const duration = Temporal.Duration.from({ years: 1 });
             const cookie = new Cookie("a", "b", { maxAge: duration });
             assert(cookie.encode().includes("Max-Age="));
+        });
+
+        it("floors a fractional Max-Age from a Temporal.Duration", () => {
+            const cookie = new Cookie("a", "b", { maxAge: { total: () => 1.5 } });
+            assert.match(cookie.encode(), /Max-Age=1$/);
         });
 
         it("handles expires as Date", () => {

--- a/packages/cookie/test/signed.test.ts
+++ b/packages/cookie/test/signed.test.ts
@@ -37,6 +37,12 @@ describe("signed", () => {
         assert.equal(jar.get("secure")?.value, "tampered-value");
     });
 
+    it("returns null for a too-short signature without throwing", () => {
+        const { signed, jar } = makeSignedJar();
+        jar.add(new Cookie("x", "short"));
+        assert.equal(signed.get("x"), null);
+    });
+
     it("roundtrip with known key and pre-signed values", () => {
         const keyBytes = Uint8Array.from([
             89, 202, 200, 125, 230, 90, 197, 245, 166, 249, 34, 169, 135, 31, 20, 197, 94, 154, 254,


### PR DESCRIPTION
## Summary
- `Cookie.parse` split on only the first two tokens, truncating any value containing `=` (raw JWTs, base64 padding), and called `decodeURIComponent` without a guard, so a malformed percent-escape threw and failed the whole request. It now splits on the first `=` and, when a component fails to decode, returns it unchanged instead of throwing (more conservative than the Rust crate's per-escape lossy decode).
- `Path` and `Domain` are written verbatim into `Set-Cookie`, so the constructor now rejects control characters and a `;` separator in them to prevent header and attribute injection.
- Signed-cookie verification now uses `timingSafeEqual` behind a length check instead of the non-constant-time `Buffer.equals`, and a fractional `Max-Age` from a `Temporal.Duration` is floored.