### PR TITLE
fix(core): reject wildcard CORS rules with a credentials predicate

### DIFF
--- a/packages/core/src/middleware/cors/allow-credentials.ts
+++ b/packages/core/src/middleware/cors/allow-credentials.ts
@@ -54,10 +54,14 @@ export class AllowCredentials {
     }
 
     /**
+     * Returns whether the header could ever be emitted as `true`, which is the
+     * case for both a static `true` and a predicate (which may return `true`
+     * for some request).
+     *
      * @internal
      */
-    public isTrue(): boolean {
-        return this.inner === true;
+    public isPossiblyTrue(): boolean {
+        return this.inner !== false;
     }
 
     /**

--- a/packages/core/src/middleware/cors/index.ts
+++ b/packages/core/src/middleware/cors/index.ts
@@ -321,7 +321,7 @@ export class CorsLayer implements HttpLayer {
     }
 
     private ensureUsableCorsRules(): void {
-        if (!this.allowCredentials_.isTrue()) {
+        if (!this.allowCredentials_.isPossiblyTrue()) {
             return;
         }
 

--- a/packages/core/test/middleware/cors/allow-credentials.test.ts
+++ b/packages/core/test/middleware/cors/allow-credentials.test.ts
@@ -11,12 +11,12 @@ describe("middleware:cors:allow-credentials", () => {
 
     it("default returns no", () => {
         const ac = AllowCredentials.default();
-        assert.equal(ac.isTrue(), false);
+        assert.equal(ac.isPossiblyTrue(), false);
     });
 
     it("yes returns true", () => {
         const ac = AllowCredentials.yes();
-        assert.equal(ac.isTrue(), true);
+        assert.equal(ac.isPossiblyTrue(), true);
         assert.deepEqual(ac.toHeader(new HeaderValue("https://example.com"), parts), [
             "access-control-allow-credentials",
             new HeaderValue("true"),
@@ -28,7 +28,7 @@ describe("middleware:cors:allow-credentials", () => {
 
     it("no returns false", () => {
         const ac = AllowCredentials.no();
-        assert.equal(ac.isTrue(), false);
+        assert.equal(ac.isPossiblyTrue(), false);
         assert.equal(ac.toHeader(new HeaderValue("https://example.com"), parts), null);
 
         const fromAc = AllowCredentials.from(false);
@@ -39,7 +39,7 @@ describe("middleware:cors:allow-credentials", () => {
         const pred: AllowCredentialsPredicate = (origin) => origin === "https://allowed.com";
         const ac = AllowCredentials.predicate(pred);
 
-        assert.equal(ac.isTrue(), false);
+        assert.equal(ac.isPossiblyTrue(), true);
         assert.deepEqual(ac.toHeader(new HeaderValue("https://allowed.com"), parts), [
             "access-control-allow-credentials",
             new HeaderValue("true"),

--- a/packages/core/test/middleware/cors/index.test.ts
+++ b/packages/core/test/middleware/cors/index.test.ts
@@ -28,13 +28,13 @@ describe("middleware:cors:index", () => {
             assert(layer["allowMethods_"].isWildcard());
             assert(layer["allowOrigin_"].isWildcard());
             assert(layer["exposeHeaders_"].isWildcard());
-            assert(!layer["allowCredentials_"].isTrue());
+            assert(!layer["allowCredentials_"].isPossiblyTrue());
         });
 
         it("veryPermissive preset sets expected defaults", () => {
             const layer = CorsLayer.veryPermissive();
 
-            assert(layer["allowCredentials_"].isTrue());
+            assert(layer["allowCredentials_"].isPossiblyTrue());
         });
 
         it("allowCredentials cannot be combined with wildcard headers", () => {
@@ -67,6 +67,24 @@ describe("middleware:cors:index", () => {
             assert.throws(() => {
                 layer.layer(dummyService);
             }, /Invalid CORS configuration: Cannot combine `access-control-allow-credentials: true` with `access-control-expose-headers: \*`/);
+        });
+
+        it("credentials predicate cannot be combined with wildcard origin", () => {
+            const layer = new CorsLayer().allowCredentials(() => true).allowOrigin(ANY);
+
+            assert.throws(() => {
+                layer.layer(dummyService);
+            }, /Invalid CORS configuration: Cannot combine `access-control-allow-credentials: true` with `access-control-allow-origin: \*`/);
+        });
+
+        it("credentials predicate is allowed with a specific origin", () => {
+            const layer = new CorsLayer()
+                .allowCredentials(() => true)
+                .allowOrigin("https://example.com");
+
+            assert.doesNotThrow(() => {
+                layer.layer(dummyService);
+            });
         });
     });
 


### PR DESCRIPTION
## Summary
- `ensureUsableCorsRules` only ran the wildcard-conflict checks when credentials was statically `true`, so configuring credentials with a predicate bypassed them and could emit `access-control-allow-credentials: true` alongside a wildcard origin, headers, methods, or expose list.
- The checks now run whenever credentials could ever be emitted as `true`, including a predicate. This intentionally diverges from tower-http, which has the same gap.