### PR TITLE
fix(fs): serve the appended index file and return 404 for malformed paths

### DIFF
--- a/packages/fs/src/open-file.ts
+++ b/packages/fs/src/open-file.ts
@@ -1,6 +1,7 @@
 /* node:coverage disable: c8 gets confused by the module mocking */
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
+import * as Path from "node:path";
 import { Encoding, type HeaderValue, type HttpRequest, Method } from "@taxum/core/http";
 import mime from "mime";
 import parseRange, { type Ranges } from "range-parser";
@@ -66,7 +67,7 @@ export const openFile = async (
     }
 
     if (req.method.equals(Method.HEAD)) {
-        const [stats, encoding] = await fileMetadataWithFallback(path, negotiatedEncodings);
+        const [stats, encoding] = await fileMetadataWithFallback(pathRef.path, negotiatedEncodings);
         const lastModified = stats.mtimeMs;
         const output = checkModifiedHeaders(lastModified, ifUnmodifiedSince, ifModifiedSince);
 
@@ -86,7 +87,7 @@ export const openFile = async (
         };
     }
 
-    const [file, encoding] = await openFileWithFallback(path, negotiatedEncodings);
+    const [file, encoding] = await openFileWithFallback(pathRef.path, negotiatedEncodings);
     const stats = await file.stat();
     const lastModified = stats.mtimeMs;
     const output = checkModifiedHeaders(lastModified, ifUnmodifiedSince, ifModifiedSince);
@@ -225,7 +226,7 @@ const maybeRedirectOrAppendPath = async (
     }
 
     if (uri.pathname.endsWith("/")) {
-        pathRef.path += "index.html";
+        pathRef.path = Path.join(pathRef.path, "index.html");
         return null;
     }
 

--- a/packages/fs/src/serve-dir.ts
+++ b/packages/fs/src/serve-dir.ts
@@ -15,7 +15,7 @@ import { SetStatusLayer } from "@taxum/core/middleware/set-status";
 import type { HttpService } from "@taxum/core/service";
 import type { Range, Ranges } from "range-parser";
 import { type OpenFileOutput, openFile } from "./open-file.js";
-import { isErrnoException } from "./util.js";
+import { isErrnoException, isInvalidPathError } from "./util.js";
 /* node:coverage enable */
 
 /**
@@ -254,11 +254,20 @@ export class ServeDir implements HttpService {
         try {
             output = await openFile(this.variant, pathToFile, req, negotiatedEncoding, rangeHeader);
         } catch (error) {
+            if (isInvalidPathError(error)) {
+                return this.handleNotFound(req);
+            }
+
             if (!isErrnoException(error)) {
                 throw error;
             }
 
-            if (error.code === "ENOENT" || error.code === "ENOTDIR" || error.code === "EACCES") {
+            if (
+                error.code === "ENOENT" ||
+                error.code === "ENOTDIR" ||
+                error.code === "EACCES" ||
+                error.code === "ENAMETOOLONG"
+            ) {
                 return this.handleNotFound(req);
             }
 
@@ -460,7 +469,14 @@ export class ServeVariant {
         }
 
         const trimmedPath = requestedPath.replace(/^\/+/, "");
-        const decodedPath = decodeURIComponent(trimmedPath);
+        let decodedPath: string;
+
+        try {
+            decodedPath = decodeURIComponent(trimmedPath);
+        } catch {
+            return null;
+        }
+
         const parts = decodedPath.split(/[\\/]+/).filter(Boolean);
         let pathToFile = basePath;
 

--- a/packages/fs/src/util.ts
+++ b/packages/fs/src/util.ts
@@ -5,3 +5,11 @@ export const isErrnoException = (error: unknown): error is NodeJS.ErrnoException
 
     return false;
 };
+
+/**
+ * Node rejects filesystem paths containing a NUL byte with a `TypeError` that
+ * carries no `errno`, so it is not an {@link isErrnoException}. Such a path can
+ * only originate from a malformed request, so we treat it as not found.
+ */
+export const isInvalidPathError = (error: unknown): boolean =>
+    error instanceof TypeError && "code" in error && error.code === "ERR_INVALID_ARG_VALUE";

--- a/packages/fs/test/serve-dir-serving.test.ts
+++ b/packages/fs/test/serve-dir-serving.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import consumers from "node:stream/consumers";
+import { describe, it } from "node:test";
+import { HttpRequest, StatusCode } from "@taxum/core/http";
+import { ServeDir } from "../src/serve-dir.js";
+
+const ASSETS = path.resolve("test/assets");
+const INDEX_FILE = path.join(ASSETS, "dir-with-index", "index.html");
+
+describe("serve-dir serving", () => {
+    it("serves the appended index.html body and content-length on GET", async () => {
+        const expected = await fs.readFile(INDEX_FILE);
+
+        const service = new ServeDir(ASSETS);
+        const req = HttpRequest.builder().method("GET").path("/dir-with-index/").body(null);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.status, StatusCode.OK);
+        assert.equal(res.headers.get("content-type")?.value, "text/html");
+        assert.equal(res.headers.get("content-length")?.value, String(expected.length));
+        assert.equal(await consumers.text(res.body.readable), expected.toString());
+    });
+
+    it("serves the appended index.html content-length on HEAD", async () => {
+        const expected = await fs.readFile(INDEX_FILE);
+
+        const service = new ServeDir(ASSETS);
+        const req = HttpRequest.builder().method("HEAD").path("/dir-with-index/").body(null);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.status, StatusCode.OK);
+        assert.equal(res.headers.get("content-length")?.value, String(expected.length));
+    });
+
+    it("returns 404 for a malformed percent-encoded path", async () => {
+        const service = new ServeDir(ASSETS);
+        const req = HttpRequest.builder().method("GET").path("/%").body(null);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.status, StatusCode.NOT_FOUND);
+    });
+
+    it("returns 404 for a path containing an encoded NUL byte", async () => {
+        const service = new ServeDir(ASSETS);
+        const req = HttpRequest.builder().method("GET").path("/foo%00bar").body(null);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.status, StatusCode.NOT_FOUND);
+    });
+
+    it("returns 404 for a path segment exceeding the maximum filename length", async () => {
+        const service = new ServeDir(ASSETS);
+        const req = HttpRequest.builder()
+            .method("GET")
+            .path(`/${"a".repeat(5000)}`)
+            .body(null);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.status, StatusCode.NOT_FOUND);
+    });
+});


### PR DESCRIPTION
## Summary
- Directory index serving opened the directory itself instead of the appended `index.html`: the mime type used the appended path but the file open and stat used the original directory path, returning a 200 with the directory size and an EISDIR when the body was read.
- A malformed percent-encoded request path, an embedded NUL byte, or an over-long path segment (`ENAMETOOLONG`) threw out of path handling and surfaced as 500; all now return 404, matching tower-http.