### PR TITLE
fix(core): tolerate content-type parameters and malformed content-type in extractors

### DIFF
--- a/packages/core/src/extract/form.ts
+++ b/packages/core/src/extract/form.ts
@@ -1,7 +1,8 @@
 import consumers from "node:stream/consumers";
+import { MIMEType } from "node:util";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { parseSearchParams } from "nested-search-params";
-import { type HttpRequest, Method, StatusCode } from "../http/index.js";
+import { type HeaderMap, type HttpRequest, Method, StatusCode } from "../http/index.js";
 import { ClientError } from "../util/index.js";
 import { ValidationError } from "./error.js";
 import type { Extractor } from "./index.js";
@@ -75,9 +76,7 @@ export const form =
         if (req.method.equals(Method.GET) || req.method.equals(Method.HEAD)) {
             source = req.uri.searchParams;
         } else {
-            if (
-                req.head.headers.get("content-type")?.value !== "application/x-www-form-urlencoded"
-            ) {
+            if (!isFormContentType(req.head.headers)) {
                 throw new MissingFormDataContentTypeError();
             }
 
@@ -94,3 +93,21 @@ export const form =
 
         return parseResult.value;
     };
+
+const isFormContentType = (headers: HeaderMap): boolean => {
+    const contentType = headers.get("content-type");
+
+    if (!contentType) {
+        return false;
+    }
+
+    let mimeType: MIMEType;
+
+    try {
+        mimeType = new MIMEType(contentType.value);
+    } catch {
+        return false;
+    }
+
+    return mimeType.type === "application" && mimeType.subtype === "x-www-form-urlencoded";
+};

--- a/packages/core/src/extract/json.ts
+++ b/packages/core/src/extract/json.ts
@@ -100,7 +100,13 @@ const isJsonContentType = (headers: HeaderMap): boolean => {
         return false;
     }
 
-    const mimeType = new MIMEType(contentType.value);
+    let mimeType: MIMEType;
+
+    try {
+        mimeType = new MIMEType(contentType.value);
+    } catch {
+        return false;
+    }
 
     return (
         mimeType.type === "application" &&

--- a/packages/core/test/extract/form.test.ts
+++ b/packages/core/test/extract/form.test.ts
@@ -35,8 +35,27 @@ describe("extract:form", () => {
         assert.deepEqual(result, { foo: "hi", bar: 123 });
     });
 
+    it("parses valid form body with content-type parameters (POST)", async () => {
+        const req = HttpRequest.builder()
+            .method("POST")
+            .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+            .body("foo=hello&bar=42");
+
+        const result = await form(schema)(req);
+        assert.deepEqual(result, { foo: "hello", bar: 42 });
+    });
+
     it("throws on missing content-type for POST", async () => {
         const req = HttpRequest.builder().method("POST").body("foo=hello&bar=42");
+
+        await assert.rejects(async () => form(schema)(req), MissingFormDataContentTypeError);
+    });
+
+    it("throws on malformed content-type for POST", async () => {
+        const req = HttpRequest.builder()
+            .method("POST")
+            .header("Content-Type", "application")
+            .body("foo=hello&bar=42");
 
         await assert.rejects(async () => form(schema)(req), MissingFormDataContentTypeError);
     });

--- a/packages/core/test/extract/json.test.ts
+++ b/packages/core/test/extract/json.test.ts
@@ -61,6 +61,28 @@ describe("extract:json", () => {
         await assert.rejects(async () => extract(req), MissingJsonContentTypeError);
     });
 
+    it("throws MissingJsonContentTypeError if content-type is malformed", async () => {
+        const req = HttpRequest.builder()
+            .method("POST")
+            .header("Content-Type", "application")
+            .body('{ "foo": "bar" }');
+
+        const extract = json(schema);
+        await assert.rejects(async () => extract(req), MissingJsonContentTypeError);
+    });
+
+    it("parses valid JSON body with content-type parameters", async () => {
+        const req = HttpRequest.builder()
+            .method("POST")
+            .header("Content-Type", "application/json; charset=UTF-8")
+            .body('{ "foo": "bar" }');
+
+        const extract = json(schema);
+        const result = await extract(req);
+
+        assert.deepEqual(result, { foo: "bar" });
+    });
+
     it("throws MalformedJsonError for invalid JSON syntax", async () => {
         const req = HttpRequest.builder()
             .method("POST")


### PR DESCRIPTION
## Summary
- The form extractor compared `Content-Type` by exact string equality and rejected a valid `application/x-www-form-urlencoded; charset=UTF-8` with 415; it now accepts the type regardless of parameters, matching axum.
- The JSON extractor constructed a `MIMEType` outside its try/catch, so a malformed `Content-Type` threw and surfaced as 500; it is now treated as missing/invalid and returns the 415 client error.