### PR TITLE
fix(core): correct body-limit boundary and always vary on compression candidates

### DIFF
--- a/packages/core/src/middleware/compression.ts
+++ b/packages/core/src/middleware/compression.ts
@@ -173,7 +173,22 @@ class ResponseCompression implements HttpService {
         const encoding = Encoding.fromHeaders(req.headers, this.accept);
         const res = await this.inner.invoke(req);
 
-        if (!this.shouldCompress(encoding, res)) {
+        if (!this.isCompressionCandidate(res)) {
+            return res;
+        }
+
+        const headers = res.headers;
+
+        const alreadyVaries = headers
+            .getAll("vary")
+            .some((value) => value.value.toLowerCase().includes("accept-encoding"));
+
+        if (!alreadyVaries) {
+            headers.append("vary", "accept-encoding");
+        }
+
+        if (encoding === Encoding.IDENTITY) {
+            // The response varies on accept-encoding, but no supported encoding was negotiated.
             return res;
         }
 
@@ -183,12 +198,6 @@ class ResponseCompression implements HttpService {
         if (!compressorBuilder) {
             // Should normally never happen, but just in case.
             return res;
-        }
-
-        const headers = res.headers;
-
-        if (!headers.get("vary")?.value.toLowerCase().includes("accept-encoding")) {
-            headers.append("vary", "accept-encoding");
         }
 
         headers.remove("accept-ranges");
@@ -201,12 +210,7 @@ class ResponseCompression implements HttpService {
         return new HttpResponse(res.status, headers, new Body(compressedStream));
     }
 
-    private shouldCompress(encoding: Encoding, res: HttpResponse): boolean {
-        if (encoding === Encoding.IDENTITY) {
-            // No compression supported.
-            return false;
-        }
-
+    private isCompressionCandidate(res: HttpResponse): boolean {
         if (
             res.headers.containsKey("content-encoding") ||
             res.headers.containsKey("content-range")

--- a/packages/core/src/middleware/limit.ts
+++ b/packages/core/src/middleware/limit.ts
@@ -63,7 +63,7 @@ class RequestBodyLimit implements HttpService {
             transform: (chunk, controller) => {
                 bytesRead += chunk.byteLength;
 
-                if (bytesRead >= this.limit) {
+                if (bytesRead > this.limit) {
                     controller.error(new ContentTooLargeError(limit));
                     return;
                 }

--- a/packages/core/test/middleware/compression.test.ts
+++ b/packages/core/test/middleware/compression.test.ts
@@ -123,6 +123,65 @@ describe("middleware/compression", () => {
         assert(!vary.includes("accept-encoding, accept-encoding"));
     });
 
+    it("does not duplicate Vary when accept-encoding is in a later vary entry", async () => {
+        const req = HttpRequest.builder().header("accept-encoding", "gzip").body(null);
+        const innerService = {
+            invoke: async () =>
+                HttpResponse.builder()
+                    .header("vary", "origin")
+                    .header("vary", "accept-encoding")
+                    .body(text),
+        };
+
+        const layer = new ResponseCompressionLayer().noDeflate().noBr().noZstd();
+        const service = layer.layer(innerService);
+
+        const res = await service.invoke(req);
+        const varyValues = res.headers.getAll("vary").map((value) => value.value.toLowerCase());
+
+        assert.deepEqual(varyValues, ["origin", "accept-encoding"]);
+    });
+
+    it("adds Vary header for a compressible response even when identity is negotiated", async () => {
+        const req = HttpRequest.builder().header("accept-encoding", "identity").body(null);
+        const layer = new ResponseCompressionLayer();
+        const service = layer.layer(dummyService);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.headers.get("content-encoding"), null);
+        const vary = res.headers.get("vary")?.value?.toLowerCase() ?? "";
+        assert(vary.includes("accept-encoding"));
+        assert.equal(await consumers.text(res.body.readable), text);
+    });
+
+    it("adds Vary header for a compressible response when accept-encoding is missing", async () => {
+        const req = HttpRequest.builder().body(null);
+        const layer = new ResponseCompressionLayer();
+        const service = layer.layer(dummyService);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.headers.get("content-encoding"), null);
+        const vary = res.headers.get("vary")?.value?.toLowerCase() ?? "";
+        assert(vary.includes("accept-encoding"));
+        assert.equal(await consumers.text(res.body.readable), text);
+    });
+
+    it("does not add Vary header for a non-compressible identity response", async () => {
+        const req = HttpRequest.builder().header("accept-encoding", "identity").body(null);
+        const innerService = {
+            invoke: async () =>
+                HttpResponse.builder().header("content-type", "application/grpc").body(text),
+        };
+        const layer = new ResponseCompressionLayer();
+        const service = layer.layer(innerService);
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.headers.get("vary"), null);
+    });
+
     it("does not compress if content-encoding already present", async () => {
         const req = HttpRequest.builder().header("accept-encoding", "gzip").body(null);
         const innerService = {

--- a/packages/core/test/middleware/limit.test.ts
+++ b/packages/core/test/middleware/limit.test.ts
@@ -83,6 +83,52 @@ describe("middleware:limit", () => {
         assert.equal(await consumers.text(res.body.readable), "hello");
     });
 
+    it("passes through a streamed body of exactly the limit", async () => {
+        const inner: HttpService = {
+            invoke: async (req) => {
+                const bodyText = await consumers.text(req.body.readable);
+                return HttpResponse.builder().body(bodyText);
+            },
+        };
+        const layer = new RequestBodyLimitLayer(5);
+        const service = layer.layer(inner);
+
+        const req = HttpRequest.builder()
+            .header("content-length", "5")
+            .body(Body.from(Buffer.from("hello")));
+
+        const res = await service.invoke(req);
+
+        assert.equal(await consumers.text(res.body.readable), "hello");
+    });
+
+    it("returns 413 if a streamed body exceeds the limit by one byte", async () => {
+        const inner: HttpService = {
+            invoke: async (req) => {
+                try {
+                    await consumers.text(req.body.readable);
+                    return HttpResponse.builder().body("should not reach here");
+                } catch (err) {
+                    if (isToHttpResponse(err)) {
+                        return err[TO_HTTP_RESPONSE]();
+                    }
+
+                    throw err;
+                }
+            },
+        };
+        const layer = new RequestBodyLimitLayer(5);
+        const service = layer.layer(inner);
+
+        const req = HttpRequest.builder()
+            .header("content-length", "5")
+            .body(Body.from(Buffer.from("hello!")));
+
+        const res = await service.invoke(req);
+
+        assert.equal(res.status.code, StatusCode.CONTENT_TOO_LARGE.code);
+    });
+
     it("returns 413 if stream emits more data than the limit", async () => {
         const inner: HttpService = {
             invoke: async (req) => {


### PR DESCRIPTION
## Summary
- The request body limit rejected a body of exactly the configured limit because the streaming counter used `>=` while the content-length pre-check used `>`; it now uses `>` consistently, matching http-body-util.
- The compression middleware only set `Vary: accept-encoding` when it actually compressed, so identity responses on compressible routes omitted it and could be mis-cached; `Vary` is now set for any compression candidate, matching tower-http.