### PR TITLE
fix(core): keep route maps consistent on conflict and set Content-Length on fallback HEAD

### DIFF
--- a/packages/core/src/routing/path-router.ts
+++ b/packages/core/src/routing/path-router.ts
@@ -272,9 +272,13 @@ class Node {
     public readonly pathToRouteId = new Map<string, number>();
 
     public insert(path: string, routeId: number): void {
+        // Attempt the find-my-way registration first: it throws on a
+        // duplicate or overlapping path, and the id maps must not be mutated
+        // when that happens, or they would be left pointing at a route id that
+        // has no corresponding entry.
+        this.findMyWay.on("GET", path, NOOP_HANDLER, { routeId });
         this.routeIdToPath.set(routeId, path);
         this.pathToRouteId.set(path, routeId);
-        this.findMyWay.on("GET", path, NOOP_HANDLER, { routeId });
     }
 
     public at(path: string): Match | null {

--- a/packages/core/src/routing/router.ts
+++ b/packages/core/src/routing/router.ts
@@ -185,7 +185,15 @@ export class Router implements HttpService {
                 return await this.pathRouter.invoke(req);
             } catch (error) {
                 if (error === ROUTE_NOT_FOUND) {
-                    return await this.catchAllFallback.route.invoke(req);
+                    const fallback = this.catchAllFallback;
+
+                    // A custom handler fallback is registered by axum as a
+                    // top-level method router, so it must run at top level to
+                    // set Content-Length and drop the body on HEAD like a normal
+                    // route. The default 404 fallback stays non-top-level.
+                    return fallback.isDefault
+                        ? await fallback.route.invoke(req)
+                        : await fallback.route.invokeInner(req);
                 }
 
                 /* node:coverage ignore next 2 */

--- a/packages/core/test/routing/path-router.test.ts
+++ b/packages/core/test/routing/path-router.test.ts
@@ -223,6 +223,43 @@ describe("routing:PathRouter", () => {
         assert.equal(await consumers.text(postRes.body.readable), "POST OK");
     });
 
+    it("keeps the route maps consistent when a conflicting registration throws", async () => {
+        const router = PathRouter.default();
+        router.route(
+            "/keep",
+            m.get(() => "get"),
+        );
+
+        assert.throws(() => {
+            router.routeEndpoint("/keep", Endpoint.route(new Route({ invoke: async () => "svc" })));
+        });
+
+        // A different, validly-registered route dispatches normally.
+        router.route(
+            "/other",
+            m.get(() => "other"),
+        );
+
+        // Re-registering a method on the conflicting path must merge rather than
+        // trip the "no registered method router" assertion that a half-updated
+        // id map would leave behind.
+        router.route(
+            "/keep",
+            m.post(() => "post"),
+        );
+
+        const otherRes = await router.invoke(makeRequest("/other"));
+        assert.equal(await consumers.text(otherRes.body.readable), "other");
+
+        const getRes = await router.invoke(makeRequest("/keep"));
+        assert.equal(await consumers.text(getRes.body.readable), "get");
+
+        const postRes = await router.invoke(
+            HttpRequest.builder().method("POST").path("/keep").body(null),
+        );
+        assert.equal(await consumers.text(postRes.body.readable), "post");
+    });
+
     it("throws if nesting path contains only a wildcard segment", () => {
         const router = PathRouter.default();
         const nested = PathRouter.default();

--- a/packages/core/test/routing/router.test.ts
+++ b/packages/core/test/routing/router.test.ts
@@ -46,6 +46,24 @@ describe("routing:Router", () => {
         assert.equal(await consumers.text(res.body.readable), "oops");
     });
 
+    it("sets content-length on a HEAD request handled by a custom fallback", async () => {
+        const body = "hello fallback";
+        const expectedLength = Buffer.byteLength(body).toString();
+
+        const router = new Router();
+        router.fallback(() => body);
+
+        const getRes = await router.invoke(
+            HttpRequest.builder().method("GET").path("/nope").body(null),
+        );
+        assert.equal(getRes.headers.get("content-length")?.value, expectedLength);
+
+        const headRes = await router.invoke(
+            HttpRequest.builder().method("HEAD").path("/nope").body(null),
+        );
+        assert.equal(headRes.headers.get("content-length")?.value, expectedLength);
+    });
+
     it("can reset fallback to default", async () => {
         const router = new Router();
         router.fallback(() => StatusCode.NO_CONTENT);


### PR DESCRIPTION
## Summary
- Registering an overlapping route mutated the internal id maps before find-my-way threw on the duplicate, leaving them corrupted; the find-my-way registration is now attempted first so a conflict throws without half-updating state, matching axum/matchit.
- A custom handler fallback ran at non-top-level and omitted `Content-Length` on HEAD responses; axum registers handler fallbacks as top-level method routers, so the custom fallback now runs top-level like a normal route.