### PR TITLE
fix(core): scope signal handlers and clean up listeners on serve() failure

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -195,6 +195,20 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
         server.unref();
     }
 
+    const abortSignal = config?.abortSignal;
+
+    const detachShutdownListeners = (): void => {
+        abortSignal?.removeEventListener("abort", closeServer);
+
+        if (config?.catchCtrlC) {
+            // Remove only taxum's own handler by reference, leaving any handlers the
+            // application registered for these signals in place.
+            process.removeListener("SIGINT", closeServer);
+            process.removeListener("SIGQUIT", closeServer);
+            process.removeListener("SIGTERM", closeServer);
+        }
+    };
+
     const closeServer = (): void => {
         /* node:coverage ignore next 3 */
         if (closing) {
@@ -202,9 +216,7 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
         }
 
         // It's important to clean up here so that Node.js will handle future signals.
-        process.removeAllListeners("SIGINT");
-        process.removeAllListeners("SIGQUIT");
-        process.removeAllListeners("SIGTERM");
+        detachShutdownListeners();
 
         closing = true;
         shutdownController.abort();
@@ -221,7 +233,7 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
         }
     };
 
-    config?.abortSignal?.addEventListener("abort", closeServer);
+    abortSignal?.addEventListener("abort", closeServer);
 
     if (config?.catchCtrlC) {
         process.addListener("SIGINT", closeServer);
@@ -230,7 +242,12 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
     }
 
     return new Promise<void>((resolve, reject) => {
-        server.on("error", reject);
+        server.on("error", (error) => {
+            // A failed listen() (e.g. EADDRINUSE) never reaches closeServer, so the shutdown
+            // listeners attached above would otherwise leak across retried serve() calls.
+            detachShutdownListeners();
+            reject(error);
+        });
 
         server.on("close", () => {
             resolve();
@@ -244,6 +261,12 @@ export const serve = async (service: HttpService, config?: ServeConfig): Promise
             );
 
             config?.onListen?.(address);
+
+            // An already-aborted signal never fires its "abort" event, so trigger the
+            // shutdown once the server is listening and can close cleanly.
+            if (abortSignal?.aborted) {
+                closeServer();
+            }
         });
     });
 };

--- a/packages/core/test/server/index.test.ts
+++ b/packages/core/test/server/index.test.ts
@@ -192,6 +192,74 @@ describe("server:index", () => {
             await serve(service, config);
         });
 
+        it("leaves application-registered signal listeners intact after shutdown", async () => {
+            const appHandler = (): void => {
+                // Application's own SIGTERM handler; must survive taxum's shutdown.
+            };
+
+            process.addListener("SIGTERM", appHandler);
+
+            const service = makeMockService(() => noContentResponse[TO_HTTP_RESPONSE]());
+            const controller = new AbortController();
+
+            const config: ServeConfig = {
+                catchCtrlC: true,
+                abortSignal: controller.signal,
+                onListen: () => {
+                    controller.abort();
+                },
+            };
+
+            await withTimeout(serve(service, config), 2000, "serve() did not resolve");
+
+            const listeners = process.listeners("SIGTERM");
+            assert(listeners.includes(appHandler), "application SIGTERM handler must remain");
+            assert.equal(listeners.length, 1, "only the application handler should remain");
+        });
+
+        it("shuts down promptly when the abort signal is already aborted", async () => {
+            const service = makeMockService(() => noContentResponse[TO_HTTP_RESPONSE]());
+            const controller = new AbortController();
+            controller.abort();
+
+            const config: ServeConfig = {
+                abortSignal: controller.signal,
+            };
+
+            await withTimeout(
+                serve(service, config),
+                2000,
+                "serve() did not resolve for an already-aborted signal",
+            );
+        });
+
+        it("removes shutdown listeners when listen fails", async () => {
+            const blocker = net.createServer();
+            await new Promise<void>((resolve) => {
+                blocker.listen(0, resolve);
+            });
+            const { port } = blocker.address() as net.AddressInfo;
+
+            const service = makeMockService(() => noContentResponse[TO_HTTP_RESPONSE]());
+            const controller = new AbortController();
+
+            const config: ServeConfig = {
+                port,
+                catchCtrlC: true,
+                abortSignal: controller.signal,
+            };
+
+            await assert.rejects(
+                withTimeout(serve(service, config), 2000, "serve() did not reject"),
+            );
+
+            blocker.close();
+
+            assert.equal(process.listeners("SIGINT").length, 0, "SIGINT listener leaked");
+            assert.equal(process.listeners("SIGQUIT").length, 0, "SIGQUIT listener leaked");
+            assert.equal(process.listeners("SIGTERM").length, 0, "SIGTERM listener leaked");
+        });
+
         it("force-closes streaming connections at the shutdown deadline", async () => {
             const encoder = new TextEncoder();
 


### PR DESCRIPTION
## Summary
- `closeServer` removed every SIGINT/SIGQUIT/SIGTERM listener, wiping an application's own handlers; it now removes only its own handler by reference.
- Signal and abort listeners added before `listen()` are now removed if listen fails, so retried `serve()` calls no longer accumulate process listeners, and an already-aborted `abortSignal` now triggers shutdown immediately.