### PR TITLE
docs: fix broken code examples across the guide

### DIFF
--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -62,7 +62,7 @@ export default withMermaid(
                 "/guide/": [
                     {
                         text: "Introduction",
-                        link: "/guide/introduction",
+                        link: "/guide",
                     },
                     {
                         text: "Getting Started",

--- a/packages/docs/src/guide/addons/cookie.md
+++ b/packages/docs/src/guide/addons/cookie.md
@@ -44,9 +44,9 @@ Use the `cookieJar` extractor to read and modify cookies inside a handler. Any m
 
 ```ts
 import { cookieJar, Cookie } from "@taxum/cookie";
-import { extractHandler } from "@taxum/core/routing";
+import { createExtractHandler } from "@taxum/core/routing";
 
-const handler = extractHandler(cookieJar, (jar) => {
+const handler = createExtractHandler(cookieJar).handler((jar) => {
     // Add a cookie
     jar.add(new Cookie("foo", "bar"));
 
@@ -63,9 +63,9 @@ Calling `.remove()` will generate a "removal cookie" (empty value, expired) in t
 
 ```ts
 import { cookieJar, Cookie } from "@taxum/cookie";
-import { extractHandler } from "@taxum/core/routing";
+import { createExtractHandler } from "@taxum/core/routing";
 
-const handler = extractHandler(cookieJar, (jar) => {
+const handler = createExtractHandler(cookieJar).handler((jar) => {
     jar.remove(new Cookie("foo"));
 
     return [jar, "cookie removed"];
@@ -78,13 +78,13 @@ Signed cookies ensure **integrity** and **authenticity**. Clients can read value
 forge them.
 
 ```ts
-import { generateKey } from "node:crypto";
+import { generateKeySync } from "node:crypto";
 import { cookieJar, Cookie } from "@taxum/cookie";
-import { extractHandler } from "@taxum/core/routing";
+import { createExtractHandler } from "@taxum/core/routing";
 
-const key = generateKey("hmac", { length: 512 });
+const key = generateKeySync("hmac", { length: 512 });
 
-const handler = extractHandler(cookieJar, (jar) => {
+const handler = createExtractHandler(cookieJar).handler((jar) => {
     const signed = jar.signed(key);
 
     signed.add(new Cookie("secure", "hello"));
@@ -103,13 +103,13 @@ Private cookies are both **encrypted** and **authenticated**, ensuring confident
 authenticity.
 
 ```ts
-import { generateKey } from "node:crypto";
+import { generateKeySync } from "node:crypto";
 import { cookieJar, Cookie } from "@taxum/cookie";
-import { extractHandler } from "@taxum/core/routing";
+import { createExtractHandler } from "@taxum/core/routing";
 
-const key = generateKey("aes", { length: 256 });
+const key = generateKeySync("aes", { length: 256 });
 
-const handler = extractHandler(cookieJar, (jar) => {
+const handler = createExtractHandler(cookieJar).handler((jar) => {
     const priv = jar.private(key);
 
     priv.add(new Cookie("secret", "hidden-value"));

--- a/packages/docs/src/guide/addons/jwt.md
+++ b/packages/docs/src/guide/addons/jwt.md
@@ -46,7 +46,7 @@ const jwtLayer = new JwtLayer(createRemoteJWKSet(
         audience: "https://{yourApi}/"
     });
 
-const router = new Route()
+const router = new Router()
     .route("/protected", m.get(() => "protected"))
     .layer(jwtLayer)
     .route("/unprotected", m.get(() => "unprotected"));
@@ -55,17 +55,16 @@ const router = new Route()
 Protected routes have access to the JWT payload via an extension key:
 
 ```ts
-import { extractHandler } from "@taxum/core/routing";
+import { createExtractHandler } from "@taxum/core/routing";
 import { extension } from "@taxum/core/extract";
 import { JWT } from "@taxum/jwt";
 
-const myHandler = extractHandler(
+const myHandler = createExtractHandler(
     extension(JWT, true),
-    (jwt) => {
-        console.log(jwt.protectedHeader);
-        console.log(jwt.payload);
-    },
-)
+).handler((jwt) => {
+    console.log(jwt.protectedHeader);
+    console.log(jwt.payload);
+});
 ```
 
 You can also allow the JWT layer to pass through unauthorized requests. In that case the JWT extension will not be set

--- a/packages/docs/src/guide/core-concepts/extensions.md
+++ b/packages/docs/src/guide/core-concepts/extensions.md
@@ -13,7 +13,7 @@ can define your own extensions like this:
 ```ts
 import { ExtensionKey } from "@taxum/core/http";
 
-const MY_EXTENSION = new ExtensionKey<string>();
+const MY_EXTENSION = new ExtensionKey<string>("My extension");
 ```
 
 The type parameter you use during construction ensures that only those values can be set and retrieved. You can insert

--- a/packages/docs/src/guide/core-concepts/middleware.md
+++ b/packages/docs/src/guide/core-concepts/middleware.md
@@ -152,7 +152,7 @@ class MyService implements HttpService {
 
     async invoke(req: HttpRequest): Promise<HttpResponse> {
         // Do something with the request
-        const res = await next.invoke(req);
+        const res = await this.inner.invoke(req);
         // Do something with the response
 
         return res;
@@ -183,7 +183,7 @@ class MyService implements HttpService {
 
     async invoke(req: HttpRequest): Promise<HttpResponse> {
         // Do something with the request
-        const res = await next.invoke(req);
+        const res = await this.inner.invoke(req);
         // Do something with the response
 
         return res;

--- a/packages/docs/src/guide/core-concepts/testing.md
+++ b/packages/docs/src/guide/core-concepts/testing.md
@@ -18,24 +18,23 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import consumers from "node:stream/consumers";
 import { query } from "@taxum/core/extract";
-import { HttpRequest, jsonResponse } from "@taxum/core/http";
-import { extractHandler } from "@taxum/core/routing";
+import { HttpRequest, jsonResponse, StatusCode } from "@taxum/core/http";
+import { createExtractHandler } from "@taxum/core/routing";
 import { z } from "zod";
 
-const myHandler = extractHandler(
+const myHandler = createExtractHandler(
     query(z.object({id: z.string()})),
-    ({id}) => jsonResponse({id}),
-);
+).handler(({id}) => jsonResponse({id}));
 
 test("handler returns correct response", async () => {
     const req = HttpRequest.builder()
         .uri(new URL("http://localhost/?id=5"))
         .body(null);
 
-    const res = myHandler(req);
+    const res = await myHandler(req);
     assert.equal(res.status, StatusCode.OK);
-    
-    const body = await consumers.json(res.body.read());
+
+    const body = await consumers.json(res.body.readable);
     assert.deepEqual(body, { id: "5" });
 });
 ```
@@ -50,8 +49,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import consumers from "node:stream/consumers";
 import { query } from "@taxum/core/extract";
-import { HttpRequest, jsonResponse } from "@taxum/core/http";
-import { extractHandler, m, Router } from "@taxum/core/routing";
+import { HttpRequest, jsonResponse, StatusCode } from "@taxum/core/http";
+import { m, Router } from "@taxum/core/routing";
 import { z } from "zod";
 
 const router = new Router();
@@ -62,10 +61,10 @@ test("router returns health response", async () => {
         .uri(new URL("http://localhost/health"))
         .body(null);
 
-    const res = router.invoke(req);
+    const res = await router.invoke(req);
     assert.equal(res.status, StatusCode.OK);
 
-    const body = await consumers.text(res.body.read());
+    const body = await consumers.text(res.body.readable);
     assert.equal(body, "healthy");
 });
 ```

--- a/packages/docs/src/guide/getting-started.md
+++ b/packages/docs/src/guide/getting-started.md
@@ -59,7 +59,7 @@ Example with [zod](https://github.com/colinhacks/zod) for validation:
 ```ts
 import { pathParam } from "@taxum/core/extract";
 import { jsonResponse } from "@taxum/core/http";
-import { extractHandler, m, Router } from "@taxum/core/routing";
+import { createExtractHandler, m, Router } from "@taxum/core/routing";
 import { serve } from "@taxum/core/server";
 import { z } from "zod";
 
@@ -70,10 +70,9 @@ const listUsers = () => jsonResponse([
 ]);
 
 // Handler with extractor for typed userId
-const getUser = extractHandler(
+const getUser = createExtractHandler(
   pathParam(z.uuid()),
-  (id) => jsonResponse({ id }),
-);
+).handler((id) => jsonResponse({ id }));
 
 const router = new Router()
   .route("/users", m.get(listUsers))


### PR DESCRIPTION
## Summary
- Fixed guide examples that referenced non-existent or misused APIs: `extractHandler` (real API is `createExtractHandler().handler()`), `new Route()` (should be `Router`), a missing `StatusCode` import, `ExtensionKey` without its required description, custom-middleware examples calling an undefined `next` instead of `this.inner`, a sidebar link to a non-existent `/guide/introduction` page, and `generateKey` used synchronously instead of `generateKeySync`.