### PR TITLE
fix(core): cancel a discarded leading response body in HttpResponse.from

### DIFF
--- a/packages/core/src/http/response.ts
+++ b/packages/core/src/http/response.ts
@@ -61,6 +61,14 @@ export class HttpResponse {
             res.status = first.status;
             res.headers.extend(first.headers);
             res.extensions.extend(first.extensions);
+
+            if (first.body.readable !== res.body.readable) {
+                first.body.readable.cancel().catch(() => {
+                    // The leading response's body is replaced by the trailing part, so
+                    // errors from cancelling the discarded stream are of no interest.
+                });
+            }
+
             return res;
         }
 

--- a/packages/core/test/http/response.test.ts
+++ b/packages/core/test/http/response.test.ts
@@ -150,6 +150,30 @@ describe("http:response", () => {
                 assert.equal(res.headers.get("c")?.value, "d");
                 assert.equal(res.status, StatusCode.OK);
             });
+
+            it("cancels a discarded leading response body", { timeout: 1000 }, async () => {
+                const { promise: cancellation, resolve: cancelled } = Promise.withResolvers<void>();
+                const leadingBody = new Body(
+                    new ReadableStream<Uint8Array>({
+                        cancel: () => {
+                            cancelled();
+                        },
+                    }),
+                );
+                const leadingRes = new HttpResponse(StatusCode.OK, new HeaderMap(), leadingBody);
+
+                const res = HttpResponse.from([leadingRes, "replacement"]);
+
+                await cancellation;
+                assert.equal(await consumers.text(res.body.readable), "replacement");
+            });
+
+            it("keeps the body when the same response is both leading and trailing part", async () => {
+                const original = HttpResponse.builder().body("payload");
+                const res = HttpResponse.from([original, original]);
+
+                assert.equal(await consumers.text(res.body.readable), "payload");
+            });
         });
 
         describe("write()", () => {


### PR DESCRIPTION
## Summary
- The tuple form `HttpResponse.from([leadingResponse, ...parts, bodyPart])` copied the leading response's status, headers, and extensions but rebuilt the body from the trailing part, leaving the leading response's body stream uncancelled and leaking its underlying resource (file handle, upstream fetch, generator finalizer).
- It now cancels the discarded body, mirroring the `discardBody` pattern in `routing/route.ts`.