### PR TITLE
fix(core): arm the SSE keep-alive timer lazily on first read

### DIFF
--- a/packages/core/src/sse/sse.ts
+++ b/packages/core/src/sse/sse.ts
@@ -139,41 +139,56 @@ export class Sse implements ToHttpResponse {
             return serialized;
         }
 
-        return serialized.pipeThrough(createKeepAliveTransform(this.keepAliveOptions));
+        return createKeepAliveStream(serialized, this.keepAliveOptions);
     }
 }
 
-const createKeepAliveTransform = (
+const createKeepAliveStream = (
+    source: ReadableStream<Uint8Array>,
     options: Required<SseKeepAliveOptions>,
-): TransformStream<Uint8Array, Uint8Array> => {
+): ReadableStream<Uint8Array> => {
     const keepAliveBytes = serializeSseEvent({ comment: options.comment });
-    let timer: ReturnType<typeof setInterval>;
+    const reader = source.getReader();
+    let timer: ReturnType<typeof setInterval> | undefined;
 
-    return new TransformStream<Uint8Array, Uint8Array>(
+    return new ReadableStream<Uint8Array>(
         {
-            start: (controller) => {
-                timer = setInterval(() => {
-                    // Skip when the consumer isn't keeping up: a buffered keep-alive serves no
-                    // purpose and would only grow the queue of a stalled connection.
-                    if ((controller.desiredSize ?? 0) > 0) {
-                        controller.enqueue(keepAliveBytes);
-                    }
-                }, options.interval);
-            },
-            transform: (chunk, controller) => {
-                controller.enqueue(chunk);
+            pull: async (controller) => {
+                if (timer === undefined) {
+                    // Arming on the first pull rather than at construction keeps the timer from
+                    // running until the body is actually read. A converted but never consumed
+                    // response is never pulled, so it leaves no interval behind.
+                    timer = setInterval(() => {
+                        // Only enqueue while the queue is drained (desiredSize is zero under a
+                        // high water mark of zero); a stalled consumer must not accumulate a
+                        // backlog of keep-alives.
+                        if ((controller.desiredSize ?? -1) >= 0) {
+                            controller.enqueue(keepAliveBytes);
+                        }
+                    }, options.interval);
+                }
+
+                const result = await reader.read().catch((error: unknown) => {
+                    clearInterval(timer);
+                    throw error;
+                });
+
+                if (result.done) {
+                    clearInterval(timer);
+                    controller.close();
+                    return;
+                }
+
+                controller.enqueue(result.value);
                 timer.refresh();
             },
-            flush: () => {
+            cancel: async (reason) => {
                 clearInterval(timer);
-            },
-            cancel: () => {
-                clearInterval(timer);
+                await reader.cancel(reason);
             },
         },
-        undefined,
-        // The readable side defaults to a high water mark of 0, under which desiredSize never
-        // rises above zero and the keep-alive check above would suppress every message.
-        { highWaterMark: 1 },
+        // A high water mark of zero keeps pull from firing until the consumer reads, which is
+        // what makes the keep-alive timer lazy.
+        { highWaterMark: 0 },
     );
 };

--- a/packages/core/test/sse/sse.test.ts
+++ b/packages/core/test/sse/sse.test.ts
@@ -246,6 +246,33 @@ describe("sse:Sse", () => {
             assert.equal(done, true);
         });
 
+        it("does not arm the keep-alive timer until the body is read", async () => {
+            const { stream } = createControllableStream();
+
+            const sse = new Sse(stream).keepAlive({ interval: 30 });
+            const reader = sse[TO_HTTP_RESPONSE]().body.readable.getReader();
+
+            // Wait well past several intervals without reading. With eager arming a keep-alive
+            // would already be buffered; with lazy arming nothing is produced until the read.
+            await delay(120);
+
+            let resolvedEarly = false;
+            const read = reader.read().then((result) => {
+                resolvedEarly = true;
+                return result;
+            });
+
+            // Far shorter than the interval: the first read must still be pending, proving no
+            // keep-alive was buffered before the read armed the timer.
+            await delay(5);
+            assert.equal(resolvedEarly, false);
+
+            const { value } = await read;
+            assert.equal(new TextDecoder().decode(value), ": \n\n");
+
+            await reader.cancel();
+        });
+
         it("uses custom keep-alive comment", async () => {
             const { stream, close } = createControllableStream();
 


### PR DESCRIPTION
## Summary
- The keep-alive interval was armed in the `TransformStream` `start()` callback, which runs when the response is built, not when the body is read. A converted-but-never-consumed SSE response (e.g. one replaced by an outer layer without being cancelled) left the interval running forever, pinning the event loop.
- The keep-alive is now a `ReadableStream` that arms the timer on the first `pull`, so it only starts once the body is actually read and an unconsumed response leaves no timer behind.
- Idle keep-alives are preserved once reading begins; a high water mark of zero keeps `pull` from firing until the consumer reads (the gate moves from `desiredSize > 0` to "queue drained" accordingly).