### PR TITLE
docs: correct DISCONNECT_SIGNAL usage guidance

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -25,9 +25,10 @@ import type { HttpService } from "../service/index.js";
  * @example
  * ```ts
  * import { extension } from "@taxum/core/extract";
+ * import { createExtractHandler } from "@taxum/core/routing";
  * import { DISCONNECT_SIGNAL } from "@taxum/core/server";
  *
- * const handler = createExtractHandler(extension(DISCONNECT_SIGNAL))((signal) => {
+ * const handler = createExtractHandler(extension(DISCONNECT_SIGNAL, true)).handler((signal) => {
  *     // ...
  * });
  * ```

--- a/packages/docs/src/guide/core-concepts/sse.md
+++ b/packages/docs/src/guide/core-concepts/sse.md
@@ -204,22 +204,33 @@ timeout.
 
 ## Client disconnects
 
-When the client disconnects, the event stream is cancelled automatically. For an async generator this runs its
-`finally` blocks, which is the place to release resources:
+When the client disconnects, the event stream is cancelled. To release resources on disconnect, listen on the
+`DISCONNECT_SIGNAL` extension rather than a generator's `finally` block. The signal aborts the moment the connection
+closes, so its listener always runs, whereas a `finally` is not guaranteed to run while the generator is waiting on its
+next event.
 
 ```ts
-async function* events(): AsyncGenerator<SseEvent> {
-    const subscription = pubsub.subscribe("news");
+import { extension } from "@taxum/core/extract";
+import { createExtractHandler } from "@taxum/core/routing";
+import { DISCONNECT_SIGNAL } from "@taxum/core/server";
+import { Sse, type SseEvent } from "@taxum/core/sse";
 
-    try {
-        for await (const message of subscription) {
-            yield { data: message };
+const handler = createExtractHandler(extension(DISCONNECT_SIGNAL, true)).handler(
+    (disconnectSignal) => {
+        const subscription = pubsub.subscribe("news");
+        disconnectSignal.addEventListener("abort", () => {
+            subscription.unsubscribe();
+        });
+
+        async function* events(): AsyncGenerator<SseEvent> {
+            for await (const message of subscription) {
+                yield { data: message };
+            }
         }
-    } finally {
-        subscription.unsubscribe();
-    }
-}
+
+        return new Sse(events());
+    },
+);
 ```
 
-If your producer performs work outside the generator, the `DISCONNECT_SIGNAL` extension provides the same information
-as an `AbortSignal`; see [Graceful Shutdown](/guide/core-concepts/graceful-shutdown#disconnect-signal).
+See [Graceful Shutdown](/guide/core-concepts/graceful-shutdown#disconnect-signal) for more on `DISCONNECT_SIGNAL`.


### PR DESCRIPTION
## Summary
- The SSE "Client disconnects" section recommended releasing resources in a generator's `finally` block, which is not guaranteed to run on disconnect (the cancellation cannot interrupt a generator waiting on its next event). It now points at `DISCONNECT_SIGNAL`, whose abort listener always runs.
- The `DISCONNECT_SIGNAL` JSDoc example used the outdated `createExtractHandler(...)(fn)` shape and was missing the `createExtractHandler` import; it now uses `createExtractHandler(...).handler(fn)` (same doc-drift class as #71, which only touched the guide files).