### PR TITLE
feat(core): add spoofing-resistant trusted-hop client IP extraction

### DIFF
--- a/packages/core/src/middleware/client-ip.ts
+++ b/packages/core/src/middleware/client-ip.ts
@@ -11,7 +11,9 @@ export const CLIENT_IP = new ExtensionKey<string>("Client IP");
 /**
  * A layer that extracts the client IP address from the request.
  *
- * If `trustProxy` is set to true, the `x-forwarded-for` header is considered.
+ * By default the direct socket peer is used. When the app sits behind one or
+ * more reverse proxies, pass the number of trusted proxies to derive the client
+ * IP from the `x-forwarded-for` header in a way a client cannot spoof.
  *
  * The client IP can later be accessed through the {@link CLIENT_IP} extension
  * key.
@@ -22,19 +24,36 @@ export const CLIENT_IP = new ExtensionKey<string>("Client IP");
  * import { m, Router } from "@taxum/core/routing";
  *
  * const router = new Router()
- *     .route("/", m.get(() => "Hello World))
- *     .layer(new SetClientIpLayer());
+ *     .route("/", m.get(() => "Hello World"))
+ *     .layer(new SetClientIpLayer(1));
  * ```
  */
 export class SetClientIpLayer implements HttpLayer {
-    private readonly trustProxy: boolean;
+    private readonly trustProxy: boolean | number;
 
     /**
      * Creates a new {@link SetClientIpLayer}.
      *
-     * @param trustProxy - whether to trust proxy headers.
+     * @param trustProxy - how to derive the client IP:
+     *   - `false` (default): use the direct socket peer and ignore
+     *     `x-forwarded-for`.
+     *   - a number: the count of trusted reverse proxies in front of the app.
+     *     The client IP is taken by skipping that many hops from the right of
+     *     the forwarding chain (`[socket peer, ...x-forwarded-for reversed]`),
+     *     which a client cannot spoof as long as the count matches the actual
+     *     number of proxies. Pass `1` for a single proxy. If the entry at that
+     *     position is not a valid IP, the socket peer is used.
+     *   - `true`: use the leftmost `x-forwarded-for` entry. This trusts the
+     *     entire forwarding chain, so any host along the way can inject a value.
+     *     Only safe on a fully controlled network; prefer a trusted-hop count.
+     * @throws {@link !Error} if a numeric hop count is negative or not an
+     *         integer.
      */
-    public constructor(trustProxy = false) {
+    public constructor(trustProxy: boolean | number = false) {
+        if (typeof trustProxy === "number" && (!Number.isInteger(trustProxy) || trustProxy < 0)) {
+            throw new Error(`Trusted hop count must be a non-negative integer, got: ${trustProxy}`);
+        }
+
         this.trustProxy = trustProxy;
     }
 
@@ -45,9 +64,9 @@ export class SetClientIpLayer implements HttpLayer {
 
 class SetClientIp implements HttpService {
     private readonly inner: HttpService;
-    private readonly trustProxy: boolean;
+    private readonly trustProxy: boolean | number;
 
-    public constructor(inner: HttpService, trustProxy: boolean) {
+    public constructor(inner: HttpService, trustProxy: boolean | number) {
         this.inner = inner;
         this.trustProxy = trustProxy;
     }
@@ -63,29 +82,45 @@ class SetClientIp implements HttpService {
             );
         }
 
-        if (!this.trustProxy) {
-            req.extensions.insert(CLIENT_IP, connectInfo.address);
-            return this.inner.invoke(req);
+        req.extensions.insert(CLIENT_IP, this.resolveClientIp(req, connectInfo.address));
+        return this.inner.invoke(req);
+    }
+
+    private resolveClientIp(req: HttpRequest, socketAddress: string): string {
+        if (this.trustProxy === false) {
+            return socketAddress;
         }
 
         const forwardedFor = req.headers.get("x-forwarded-for");
 
         if (!forwardedFor) {
-            req.extensions.insert(CLIENT_IP, connectInfo.address);
-            return this.inner.invoke(req);
+            return socketAddress;
         }
 
-        const ips = forwardedFor.value
+        const entries = forwardedFor.value
             .split(",")
-            .map((ip) => ip.trim())
-            .filter((ip) => isIP(ip) !== 0);
+            .map((entry) => entry.trim())
+            .filter((entry) => entry.length > 0);
 
-        if (ips.length === 0) {
-            req.extensions.insert(CLIENT_IP, connectInfo.address);
-            return this.inner.invoke(req);
+        if (entries.length === 0) {
+            return socketAddress;
         }
 
-        req.extensions.insert(CLIENT_IP, ips[0]);
-        return this.inner.invoke(req);
+        if (this.trustProxy === true) {
+            // Trust the whole chain: the leftmost claimed client, skipping any
+            // non-IP entries.
+            return entries.find((entry) => isIP(entry) !== 0) ?? socketAddress;
+        }
+
+        // Count trusted hops from the right of the forwarding chain. The positions
+        // must be taken on the raw list: dropping non-IP entries first could pull
+        // an untrusted value into a trusted slot when a trusted proxy emits a
+        // non-IP token (an obfuscated identifier or a port-suffixed address). The
+        // final selected value is validated instead, falling back to the socket
+        // peer rather than to a value from beyond the trust boundary.
+        const chain = [socketAddress, ...entries.reverse()];
+        const candidate = chain[Math.min(this.trustProxy, chain.length - 1)];
+
+        return isIP(candidate) !== 0 ? candidate : socketAddress;
     }
 }

--- a/packages/core/test/middleware/client-ip.test.ts
+++ b/packages/core/test/middleware/client-ip.test.ts
@@ -7,6 +7,31 @@ import { CLIENT_IP, SetClientIpLayer } from "../../src/middleware/client-ip.js";
 describe("middleware/client-ip", () => {
     const dummyResponse = HttpResponse.builder().body(null);
 
+    const clientIpFor = async (
+        trustProxy: boolean | number,
+        socketAddress: string,
+        forwardedFor?: string,
+    ): Promise<string | undefined> => {
+        let clientIp: string | undefined;
+        const innerService = {
+            invoke: async (req: HttpRequest) => {
+                clientIp = req.extensions.get(CLIENT_IP);
+                return dummyResponse;
+            },
+        };
+
+        let builder = HttpRequest.builder().connectInfo(
+            new SocketAddress({ address: socketAddress }),
+        );
+
+        if (forwardedFor !== undefined) {
+            builder = builder.header("x-forwarded-for", forwardedFor);
+        }
+
+        await new SetClientIpLayer(trustProxy).layer(innerService).invoke(builder.body(null));
+        return clientIp;
+    };
+
     it("throws when connect info is absent", async () => {
         const innerService = {
             invoke: async () => dummyResponse,
@@ -115,5 +140,63 @@ describe("middleware/client-ip", () => {
             .body(null);
 
         await service.invoke(req);
+    });
+
+    it("ignores a client-spoofed x-forwarded-for entry with a single trusted proxy", async () => {
+        assert.equal(await clientIpFor(1, "10.0.0.1", "9.9.9.9, 203.0.113.7"), "203.0.113.7");
+    });
+
+    it("falls back to the socket peer when the trusted entry is not a valid IP", async () => {
+        assert.equal(await clientIpFor(1, "10.0.0.1", "9.9.9.9, _hidden"), "10.0.0.1");
+    });
+
+    it("uses the rightmost entry with a single trusted proxy", async () => {
+        assert.equal(await clientIpFor(1, "10.0.0.1", "203.0.113.1, 198.51.100.2"), "198.51.100.2");
+    });
+
+    it("walks two hops with two trusted proxies", async () => {
+        assert.equal(await clientIpFor(2, "10.0.0.1", "203.0.113.1, 198.51.100.2"), "203.0.113.1");
+    });
+
+    it("falls back to the socket peer with a hop count and no x-forwarded-for", async () => {
+        assert.equal(await clientIpFor(1, "10.0.0.1"), "10.0.0.1");
+    });
+
+    it("counts non-IP entries as positions instead of filtering them", async () => {
+        assert.equal(
+            await clientIpFor(2, "10.0.0.1", "203.0.113.1, junk, 198.51.100.2"),
+            "10.0.0.1",
+        );
+    });
+
+    it("throws for a negative or non-integer hop count", () => {
+        assert.throws(() => new SetClientIpLayer(-1), /non-negative integer/);
+        assert.throws(() => new SetClientIpLayer(1.5), /non-negative integer/);
+    });
+
+    it("uses the socket peer for a hop count of zero", async () => {
+        assert.equal(await clientIpFor(0, "10.0.0.1", "203.0.113.1, 198.51.100.2"), "10.0.0.1");
+    });
+
+    it("clamps a hop count larger than the chain to the leftmost entry", async () => {
+        assert.equal(await clientIpFor(99, "10.0.0.1", "203.0.113.1, 198.51.100.2"), "203.0.113.1");
+    });
+
+    it("uses the leftmost valid entry when trustProxy is true, skipping non-IP entries", async () => {
+        assert.equal(
+            await clientIpFor(true, "10.0.0.1", "_hidden, 203.0.113.1, 198.51.100.2"),
+            "203.0.113.1",
+        );
+    });
+
+    it("does not let client-prepended entries shift the trusted slot with two proxies", async () => {
+        assert.equal(
+            await clientIpFor(2, "10.0.0.1", "1.1.1.1, 2.2.2.2, 203.0.113.7, 192.168.0.5"),
+            "203.0.113.7",
+        );
+    });
+
+    it("resolves an IPv6 client IP in the hop-count path", async () => {
+        assert.equal(await clientIpFor(1, "10.0.0.1", "2001:db8::1, 2001:db8::2"), "2001:db8::2");
     });
 });


### PR DESCRIPTION
## Summary
- `SetClientIpLayer`'s `trustProxy: true` takes the **leftmost** `x-forwarded-for` entry, which a client can spoof. The parameter now also accepts a **number** (the count of trusted reverse proxies) and derives the client IP by counting that many hops from the right of the forwarding chain (`[socket peer, ...x-forwarded-for reversed]`), which a client cannot spoof as long as the count matches the real proxy count. Pass `1` for a single proxy.
- Positions are counted on the **raw** forwarded-for entries, not a pre-filtered valid-IP subset. Filtering by `isIP` first would let a non-IP token emitted by a trusted proxy (an obfuscated identifier, a port-suffixed address) collapse the chain and pull an attacker-controlled value into a trusted slot. The finally-selected value is validated and falls back to the socket peer if it is not a valid IP.
- `false` (default, socket peer) and `true` (leftmost, now documented as trusting the entire chain and only safe on a controlled network) are unchanged, so this is additive and not API-breaking.

10 new tests cover the spoof-resistance property, the non-IP-trusted-entry fallback, the counting model, validation, and the preserved legacy paths.