### PR TITLE
fix(fs): keep a real extension when identity encoding is negotiated

### DIFF
--- a/packages/fs/src/open-file.ts
+++ b/packages/fs/src/open-file.ts
@@ -137,11 +137,11 @@ const openFileWithFallback = async (
             const file = await fs.open(pathRef.path, "r");
             return [file, encoding];
         } catch (error) {
-            if (!(encoding && isErrnoException(error) && error.code === "ENOENT")) {
+            if (!(encoding?.fileExtension && isErrnoException(error) && error.code === "ENOENT")) {
                 throw error;
             }
 
-            pathRef.path = pathRef.path.replace(/\.[a-z]+$/, "");
+            pathRef.path = pathRef.path.slice(0, -encoding.fileExtension.length);
             encodings = encodings.filter(([current]) => current !== encoding);
         }
     }
@@ -161,11 +161,11 @@ const fileMetadataWithFallback = async (
             const stats = await fs.stat(pathRef.path);
             return [stats, encoding];
         } catch (error) {
-            if (!(encoding && isErrnoException(error) && error.code === "ENOENT")) {
+            if (!(encoding?.fileExtension && isErrnoException(error) && error.code === "ENOENT")) {
                 throw error;
             }
 
-            pathRef.path = pathRef.path.replace(/\.[a-z]+$/, "");
+            pathRef.path = pathRef.path.slice(0, -encoding.fileExtension.length);
             encodings = encodings.filter(([current]) => current !== encoding);
         }
     }
@@ -203,7 +203,7 @@ const preferredEncoding = (
         return null;
     }
 
-    /* node:coverage ignore next 3: can never happen, just for safety */
+    // Identity carries no file extension, so the requested path is served unchanged.
     if (!preferredEncoding.fileExtension) {
         return preferredEncoding;
     }

--- a/packages/fs/test/open-file.test.ts
+++ b/packages/fs/test/open-file.test.ts
@@ -250,6 +250,28 @@ describe("open-file", () => {
         await output.extent.file.close();
     });
 
+    it("does not strip a real extension when identity is negotiated (GET)", async () => {
+        const req = createReq("GET");
+        const negotiatedEncodings: [Encoding, number][] = [[Encoding.IDENTITY, 1]];
+        const missing = path.join(TEST_DIR, "unknown.txt");
+
+        await assert.rejects(
+            openFile(fileVariant, missing, req, negotiatedEncodings, null),
+            (error: unknown) => isErrnoException(error) && error.code === "ENOENT",
+        );
+    });
+
+    it("does not strip a real extension when identity is negotiated (HEAD)", async () => {
+        const req = createReq("HEAD");
+        const negotiatedEncodings: [Encoding, number][] = [[Encoding.IDENTITY, 1]];
+        const missing = path.join(TEST_DIR, "unknown.txt");
+
+        await assert.rejects(
+            openFile(fileVariant, missing, req, negotiatedEncodings, null),
+            (error: unknown) => isErrnoException(error) && error.code === "ENOENT",
+        );
+    });
+
     it("returns to HEAD with negotiated encoding fallback (gzip)", async () => {
         const req = createReq("HEAD");
         const negotiatedEncodings: [Encoding, number][] = [


### PR DESCRIPTION
## Summary
- The precompressed-file fallback stripped a trailing extension off the requested path whenever a negotiated encoding's file was missing. The `identity` encoding carries no file extension yet still triggered the fallback, so `GET /data.json` with `Accept-Encoding: identity` returned the contents of `data` as `application/json` when only `data` exists.
- The fallback is now restricted to encodings that actually appended an extension, stripping exactly that suffix instead of a greedy regex. Corrects the stale comment claiming the identity branch was unreachable, since it runs whenever a client negotiates `identity`.
