### PR TITLE
fix(core): prevent a __proto__ header from reparenting serialized output

### DIFF
--- a/packages/core/src/http/headers.ts
+++ b/packages/core/src/http/headers.ts
@@ -248,8 +248,17 @@ export class HeaderMap implements ToHttpResponseParts {
                 continue;
             }
 
-            result[name] =
-                exposed.length === 1 ? exposed[0].toJSON() : exposed.map((value) => value.toJSON());
+            // defineProperty rather than assignment so a header named `__proto__` becomes an
+            // own property instead of reparenting the result via the prototype setter.
+            Object.defineProperty(result, name, {
+                value:
+                    exposed.length === 1
+                        ? exposed[0].toJSON()
+                        : exposed.map((value) => value.toJSON()),
+                enumerable: true,
+                writable: true,
+                configurable: true,
+            });
         }
 
         return result;
@@ -263,7 +272,14 @@ export class HeaderMap implements ToHttpResponseParts {
         const result: Record<string, HeaderValue | HeaderValue[]> = {};
 
         for (const [key, values] of this.map) {
-            result[key] = values.length === 1 ? values[0] : values;
+            // defineProperty rather than assignment so a header named `__proto__` becomes an
+            // own property instead of reparenting the result via the prototype setter.
+            Object.defineProperty(result, key, {
+                value: values.length === 1 ? values[0] : values,
+                enumerable: true,
+                writable: true,
+                configurable: true,
+            });
         }
 
         return inspect(result, options);

--- a/packages/core/test/http/headers.test.ts
+++ b/packages/core/test/http/headers.test.ts
@@ -185,6 +185,21 @@ describe("http:headers", () => {
             const inspected = util.inspect(map);
             assert.equal(inspected, "{ authorization: Sensitive }");
         });
+
+        it("toJSON keeps a __proto__ header as an own property without reparenting", () => {
+            const map = HeaderMap.from([["__proto__", "evil"]]);
+            const json = map.toJSON();
+
+            assert.equal(Object.getOwnPropertyDescriptor(json, "__proto__")?.value, "evil");
+            assert.equal(JSON.stringify(map), '{"__proto__":"evil"}');
+        });
+
+        it("inspect shows a __proto__ header without reparenting", () => {
+            const map = HeaderMap.from([["__proto__", "evil"]]);
+            const inspected = util.inspect(map);
+
+            assert.match(inspected, /__proto__/);
+        });
     });
 
     describe("HeaderValue", () => {


### PR DESCRIPTION
## Summary
- `HeaderMap.toJSON` and the `util.inspect` helper assigned client-supplied header names onto a plain object. A header named `__proto__` carries an object value (a `HeaderValue` or an array of them), so the assignment invoked the prototype setter and reparented the result, dropping the header from serialized and inspected output. This is reachable via `HttpRequest.toJSON`, i.e. any structured logging of a request.
- Both sinks now define properties with `Object.defineProperty`, so such a name becomes an own property instead of hitting the setter. The returned object keeps its normal prototype, so structural comparisons are unaffected.
