### PR TITLE
fix(core): match a literal dot in the q-value pattern

### DIFF
--- a/packages/core/src/http/content-encoding.ts
+++ b/packages/core/src/http/content-encoding.ts
@@ -132,7 +132,7 @@ export const encodings = (
         }, []);
 };
 
-const qValueRegex = /^[01](?:.\d{0,3})?$/;
+const qValueRegex = /^[01](?:\.\d{0,3})?$/;
 
 /**
  * Parses a Q-value string from an input and returns its numerical

--- a/packages/core/test/http/content-encoding.test.ts
+++ b/packages/core/test/http/content-encoding.test.ts
@@ -71,6 +71,8 @@ describe("http:content-encoding", () => {
             assert.equal(parseQValue("p=0.5"), null);
             assert.equal(parseQValue("q=abc"), null);
             assert.equal(parseQValue("q=0.1234"), null);
+            assert.equal(parseQValue("q=0x5"), null);
+            assert.equal(parseQValue("q=1a"), null);
         });
     });
 


### PR DESCRIPTION
## Summary
- The q-value regex used an unescaped `.`, so malformed values such as `q=0x5` or `q=1a` passed validation. `Number.parseFloat` then stopped at the invalid character and the range clamp still rejected anything above 1, so no wrong encoding was ever selected, but the pattern accepted input it should have refused. The dot is now escaped so only a genuine decimal is allowed.
