### PR TITLE
fix(core): correct framing for bodyless and empty-body responses

### DIFF
--- a/packages/core/src/routing/route.ts
+++ b/packages/core/src/routing/route.ts
@@ -6,6 +6,7 @@ import {
     type HttpResponseLike,
     Method,
     type SizeHint,
+    StatusCode,
 } from "../http/index.js";
 import type { HttpLayer } from "../layer/index.js";
 import { getLoggerProxy } from "../logging/index.js";
@@ -52,10 +53,19 @@ export class Route implements HttpService {
                 discardBody(res);
             }
         } else if (topLevel) {
-            setContentLength(res.headers, res.body.sizeHint);
-
-            if (req.method.equals(Method.HEAD)) {
+            if (isBodyless(res.status)) {
+                // A 1xx, 204, or 304 response must not carry a body or its framing headers
+                // (RFC 9110 §8.6). Node strips the body but keeps a Content-Length we or the
+                // handler set, which would advertise a length the wire never delivers.
+                res.headers.remove("content-length");
+                res.headers.remove("transfer-encoding");
                 discardBody(res);
+            } else {
+                setContentLength(res.headers, res.body.sizeHint);
+
+                if (req.method.equals(Method.HEAD)) {
+                    discardBody(res);
+                }
             }
         }
 
@@ -78,6 +88,11 @@ const discardBody = (res: HttpResponse): void => {
     res.body = Body.from(null);
 };
 
+const isBodyless = (status: StatusCode): boolean =>
+    status.isInformational() ||
+    status.code === StatusCode.NO_CONTENT.code ||
+    status.code === StatusCode.NOT_MODIFIED.code;
+
 const setContentLength = (headers: HeaderMap, sizeHint: SizeHint): void => {
     if (headers.containsKey("content-length")) {
         return;
@@ -85,7 +100,7 @@ const setContentLength = (headers: HeaderMap, sizeHint: SizeHint): void => {
 
     const exactSize = sizeHint.exact();
 
-    if (!exactSize) {
+    if (exactSize === null) {
         return;
     }
 

--- a/packages/core/test/routing/route.test.ts
+++ b/packages/core/test/routing/route.test.ts
@@ -55,6 +55,89 @@ describe("routing:route", () => {
         assert.equal(res.headers.get("content-length")?.value, "3");
     });
 
+    it("sets Content-Length: 0 for an empty body", async () => {
+        const route = routeFrom(() => "");
+
+        const req = HttpRequest.builder().body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(res.headers.get("content-length")?.value, "0");
+    });
+
+    it("does not set Content-Length for an unknown-size body", async () => {
+        const stream = new ReadableStream<Uint8Array>({
+            start: (controller) => {
+                controller.enqueue(new TextEncoder().encode("x"));
+                controller.close();
+            },
+        });
+        const route = new Route({
+            invoke: async () => HttpResponse.builder().body(stream),
+        });
+
+        const req = HttpRequest.builder().body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(res.headers.get("content-length"), null);
+        await res.body.readable.cancel();
+    });
+
+    it("keeps Content-Length but clears the body for HEAD", async () => {
+        const route = routeFrom(() => "abc");
+
+        const req = HttpRequest.builder().method("HEAD").body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(res.headers.get("content-length")?.value, "3");
+        assert.equal(await consumers.text(res.body.readable), "");
+    });
+
+    it("strips framing headers and body on a 1xx response", async () => {
+        const route = routeFrom(() => [StatusCode.CONTINUE, "interim"]);
+
+        const req = HttpRequest.builder().body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(res.headers.get("content-length"), null);
+        assert.equal(await consumers.text(res.body.readable), "");
+    });
+
+    it("strips framing headers and body on a 204 response", async () => {
+        const route = routeFrom(() => [StatusCode.NO_CONTENT, "unexpected"]);
+
+        const req = HttpRequest.builder().body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(res.headers.get("content-length"), null);
+        assert.equal(res.headers.get("transfer-encoding"), null);
+        assert.equal(await consumers.text(res.body.readable), "");
+    });
+
+    it("removes a handler-set Content-Length on a 204 response", async () => {
+        const route = new Route({
+            invoke: async () =>
+                HttpResponse.builder()
+                    .status(StatusCode.NO_CONTENT)
+                    .header("content-length", "5")
+                    .body(null),
+        });
+
+        const req = HttpRequest.builder().body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(res.headers.get("content-length"), null);
+    });
+
+    it("strips framing headers and body on a 304 response", async () => {
+        const route = routeFrom(() => [StatusCode.NOT_MODIFIED, "cached"]);
+
+        const req = HttpRequest.builder().body(null);
+        const res = await route.invokeInner(req);
+
+        assert.equal(res.headers.get("content-length"), null);
+        assert.equal(await consumers.text(res.body.readable), "");
+    });
+
     it("does not override existing Content-Length", async () => {
         const route = new Route({
             invoke: async () => HttpResponse.builder().header("content-length", "999").body("abc"),


### PR DESCRIPTION
## Summary
- A 1xx, 204, or 304 response must not carry a body or a `Content-Length`/`Transfer-Encoding` header (RFC 9110 §8.6). Node strips the body for these statuses but keeps a `Content-Length` the handler or taxum set, emitting a frame that advertises bytes the wire never delivers and can desync a keep-alive connection. These responses now drop those headers and discard the body at the top level, matching hyper's encoder.
- `setContentLength` treated an exact size of 0 as unknown and left an empty body unframed, so Node fell back to chunked encoding. An empty body now gets a zero-length `Content-Length`, matching hyper, which reserves chunked for genuinely unknown-length bodies.