### PR TITLE
fix(cookie): accept a signed cookie with an empty value

### DIFF
--- a/packages/cookie/src/signed.ts
+++ b/packages/cookie/src/signed.ts
@@ -72,7 +72,7 @@ export class SignedJar {
 
     private verify(cookie: Cookie): Cookie | null {
         const value = this.verifyValue(cookie.value);
-        return value ? cookie.withValue(value) : null;
+        return value !== null ? cookie.withValue(value) : null;
     }
 
     private verifyValue(cookieValue: string): string | null {

--- a/packages/cookie/test/signed.test.ts
+++ b/packages/cookie/test/signed.test.ts
@@ -43,6 +43,15 @@ describe("signed", () => {
         assert.equal(signed.get("x"), null);
     });
 
+    it("verifies a signed cookie with an empty value", () => {
+        const { signed } = makeSignedJar();
+        signed.add(new Cookie("session", ""));
+
+        const verified = signed.get("session");
+        assert.notEqual(verified, null);
+        assert.equal(verified?.value, "");
+    });
+
     it("roundtrip with known key and pre-signed values", () => {
         const keyBytes = Uint8Array.from([
             89, 202, 200, 125, 230, 90, 197, 245, 166, 249, 34, 169, 135, 31, 20, 197, 94, 154, 254,


### PR DESCRIPTION
## Summary
- `SignedJar.verify` treated the verified value as falsy, so a correctly signed empty-string value was rejected and returned `null`. It now compares against `null` explicitly, so an authentic empty value verifies like any other.