### PR TITLE
fix(cookie): bind the cookie name into the signed HMAC

### DIFF
--- a/packages/cookie/src/signed.ts
+++ b/packages/cookie/src/signed.ts
@@ -64,6 +64,7 @@ export class SignedJar {
 
     private sign(cookie: Cookie): Cookie {
         const hmac = createHmac("sha256", this.key);
+        hmac.update(cookie.name);
         hmac.update(cookie.value);
         const signature = hmac.digest("base64");
 
@@ -71,16 +72,17 @@ export class SignedJar {
     }
 
     private verify(cookie: Cookie): Cookie | null {
-        const value = this.verifyValue(cookie.value);
+        const value = this.verifyValue(cookie.name, cookie.value);
         return value !== null ? cookie.withValue(value) : null;
     }
 
-    private verifyValue(cookieValue: string): string | null {
+    private verifyValue(name: string, cookieValue: string): string | null {
         const signature = cookieValue.slice(0, BASE64_DIGEST_LEN);
         const value = cookieValue.slice(BASE64_DIGEST_LEN);
         const digest = Buffer.from(signature, "base64");
 
         const hmac = createHmac("sha256", this.key);
+        hmac.update(name);
         hmac.update(value);
         const actualDigest = hmac.digest();
 

--- a/packages/cookie/test/signed.test.ts
+++ b/packages/cookie/test/signed.test.ts
@@ -52,22 +52,16 @@ describe("signed", () => {
         assert.equal(verified?.value, "");
     });
 
-    it("roundtrip with known key and pre-signed values", () => {
-        const keyBytes = Uint8Array.from([
-            89, 202, 200, 125, 230, 90, 197, 245, 166, 249, 34, 169, 135, 31, 20, 197, 94, 154, 254,
-            79, 60, 26, 8, 143, 254, 24, 116, 138, 92, 225, 159, 60, 157, 41, 135, 129, 31, 226,
-            196, 16, 198, 168, 134, 4, 42, 1, 196, 24, 57, 103, 241, 147, 201, 185, 233, 10, 180,
-            170, 187, 89, 252, 137, 110, 107,
-        ]);
-        const key = Buffer.from(keyBytes);
-        const jar = new CookieJar();
+    it("does not verify a signed value moved to a different cookie name", () => {
+        const { signed, jar } = makeSignedJar();
+        signed.add(new Cookie("a", "value"));
 
-        jar.add(new Cookie("a", "TvVFEniX3o7tcNAi76ZHKG4QQCpLJCnZkc5Oq8J87bY=Tamper-proof"));
-        jar.add(new Cookie("b", "TvVFEniX3o7tcNAi76ZHKG4QQCpLJCnZkc5Oq8J87bY=Tamper-proof"));
+        const signedValue = jar.get("a")?.value;
+        assert(signedValue);
 
-        const signed = new SignedJar(jar, key);
+        jar.add(new Cookie("b", signedValue));
 
-        assert.equal(signed.get("a")?.value, "Tamper-proof");
-        assert.equal(signed.get("b")?.value, "Tamper-proof");
+        assert.equal(signed.get("a")?.value, "value");
+        assert.equal(signed.get("b"), null);
     });
 });


### PR DESCRIPTION
## Summary
- `SignedJar` computed the HMAC over the cookie value alone, so a signed value was valid under any cookie name. A client could copy a signed blob from one name to another and have it verify, breaking the name-to-value binding that `PrivateJar` already provides through its AAD.
- The cookie name is now folded into the HMAC on both sign and verify, matching cookie-rs.

> [!NOTE]
> This changes the on-the-wire signature format, so cookies signed by an earlier version no longer verify and are treated as tampered.