### PR TITLE
fix(core): bump nested-search-params to 1.0.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -197,7 +197,7 @@
     "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "find-my-way": "^9.5.0",
-        "nested-search-params": "^1.0.1",
+        "nested-search-params": "^1.0.2",
         "ts-pattern": "^5.9.0"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^9.5.0
         version: 9.5.0
       nested-search-params:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.0.2
+        version: 1.0.2
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
@@ -1744,8 +1744,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nested-search-params@1.0.1:
-    resolution: {integrity: sha512-UMjp93iO3PnDzLNH6XRt6xM20OoMnxy9XZf9j3EKwmrQgYJy24dU6+cSlpZTbYgBV9+QLtUYij9vGMuyqtAuYA==}
+  nested-search-params@1.0.2:
+    resolution: {integrity: sha512-nWMEe4O7C/lSYwkhMbl7xv7HQCZrNPK3RGa+CCb893ToMeDCoY8QbAxfYstuJUvxY+C8j7JDbtH0oa9y6LaI4w==}
 
   non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
@@ -3808,7 +3808,7 @@ snapshots:
 
   nanoid@3.3.15: {}
 
-  nested-search-params@1.0.1: {}
+  nested-search-params@1.0.2: {}
 
   non-layered-tidy-tree-layout@2.0.2:
     optional: true


### PR DESCRIPTION
## Summary
- Bumps `nested-search-params` to 1.0.2, which fixes an event-loop denial of service: a query or form key with an out-of-range numeric index (e.g. `a[4294967294]=x`) inflated a native array toward its 2^32 ceiling and stalled the event loop for tens of seconds.
- The `query()` and `form()` extractors pass untrusted input straight to the parser, so this closes that vector downstream.