### PR TITLE
feat: add testing package

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -23,6 +23,7 @@ jobs:
             cookie
             fs
             jwt
+            testing
             examples
             docs
             deps

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,3 +28,7 @@ component_management:
       name: JWT
       paths:
         - packages/jwt/**
+    - component_id: testing
+      name: Testing
+      paths:
+        - packages/testing/**

--- a/packages/docs/src/guide/core-concepts/testing.md
+++ b/packages/docs/src/guide/core-concepts/testing.md
@@ -1,70 +1,252 @@
 ---
-description: Testing your handlers and middleware. 
+description: Testing your handlers and taxum stacks with @taxum/testing.
 ---
 
 # Testing
 
-Taxum is built with testability in mind. You have two ways to test your application; either through unit testing or
-integration testing.
+Taxum ships a dedicated test client in `@taxum/testing`. It runs requests through your stack in-process, without
+opening a socket: routes, extractors, and middleware execute the same way as under `serve()`, with a few
+connection-level exceptions covered in [What stays outside](#what-stays-outside). Requests and responses stay plain
+objects you can assert on.
 
-## Unit Testing
+## Installation
 
-To test individual units of your application, e.g. your handlers, all you have to do is create an HTTP request and make
-assertions on the HTTP response. There is a builder on the `HttpRequest` to make your life easier. To assert things
-about the body, it is recommended to use Node.js' `consumers` utility to read the body.
+The package is only needed at development time:
 
-```ts
-import assert from "node:assert/strict";
-import { test } from "node:test";
-import consumers from "node:stream/consumers";
-import { query } from "@taxum/core/extract";
-import { HttpRequest, jsonResponse, StatusCode } from "@taxum/core/http";
-import { createExtractHandler } from "@taxum/core/routing";
-import { z } from "zod";
+::: code-group
 
-const myHandler = createExtractHandler(
-    query(z.object({id: z.string()})),
-).handler(({id}) => jsonResponse({id}));
-
-test("handler returns correct response", async () => {
-    const req = HttpRequest.builder()
-        .uri(new URL("http://localhost/?id=5"))
-        .body(null);
-
-    const res = await myHandler(req);
-    assert.equal(res.status, StatusCode.OK);
-
-    const body = await consumers.json(res.body.readable);
-    assert.deepEqual(body, { id: "5" });
-});
+```sh [npm]
+$ npm add -D @taxum/testing
 ```
 
-## Integration Testing
+```sh [pnpm]
+$ pnpm add -D @taxum/testing
+```
 
-Alternatively to unit testing, you can also test the entire request flow through all layers. This works similar to unit
-testing, except that you invoke the router directly:
+```sh [yarn]
+$ yarn add -D @taxum/testing
+```
+
+```sh [bun]
+$ bun add -D @taxum/testing
+```
+
+:::
+
+## Your first test
+
+Create a client from a router and await requests on it:
 
 ```ts
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import consumers from "node:stream/consumers";
-import { query } from "@taxum/core/extract";
-import { HttpRequest, jsonResponse, StatusCode } from "@taxum/core/http";
 import { m, Router } from "@taxum/core/routing";
-import { z } from "zod";
+import { testClient } from "@taxum/testing";
 
-const router = new Router();
-    router.route("/health", m.get(() => "healthy"));
+const router = new Router().route("/health", m.get(() => "healthy"));
 
-test("router returns health response", async () => {
-    const req = HttpRequest.builder()
-        .uri(new URL("http://localhost/health"))
-        .body(null);
+test("health endpoint responds", async () => {
+    const res = await testClient(router).get("/health");
 
-    const res = await router.invoke(req);
-    assert.equal(res.status, StatusCode.OK);
-
-    const body = await consumers.text(res.body.readable);
-    assert.equal(body, "healthy");
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "healthy");
 });
 ```
+
+`testClient()` accepts any `HttpService`, not just a `Router`, so a stack wrapped in middleware layers tests the same
+way.
+
+## Building requests
+
+Every HTTP verb has a method (`get`, `post`, `put`, `patch`, `delete`, `head`, `options`). The returned request is
+thenable: awaiting it sends it. Before that, you can chain configuration:
+
+```ts
+const res = await client
+    .post("/users")
+    .header("authorization", `Bearer ${token}`)
+    .query({ notify: true })
+    .json({ name: "Ben" });
+```
+
+- `.query()` takes a flat record (arrays become repeated keys), a `URLSearchParams`, or a pre-formed query string,
+  e.g. nested bracket syntax: `.query("filter[status]=open")`.
+- `.json(value)` sets a JSON body and implies `content-type: application/json`.
+- `.form(record)` sets a URL-encoded body and implies `content-type: application/x-www-form-urlencoded`.
+- `.body(bodyLike)` sets a raw body (string, `Buffer`, stream, ...) and implies nothing.
+- `.cookie(name, value)` adds a request cookie; `.headers(entries)` appends in bulk.
+
+An explicit `.header("content-type", ...)` always wins over the implied one. `content-length` is set automatically
+for buffered bodies, so body-limit middleware behaves as in production.
+
+A request carries at most one body: once `.json()`, `.form()`, or `.body()` has been called, the body setters
+disappear from the type, so a second call doesn't compile.
+
+Requests send exactly once. Awaiting the same request again returns the same response, and calling a setter after the
+send throws.
+
+## Asserting on responses
+
+Responses read like fetch `Response` objects: `status` is a plain number, `headers` is a native
+[`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, and the body readers are async. Unlike
+fetch, the body is buffered on first read, so you can read it repeatedly and in different formats:
+
+```ts
+const res = await client.get("/users/5");
+
+assert.equal(res.status, 200);
+assert.equal(res.headers.get("content-type"), "application/json");
+assert.deepEqual(await res.json(), { id: "5" });
+assert.match(await res.text(), /"id"/);
+```
+
+Bodies are decompressed automatically based on the `content-encoding` header, so
+[compression middleware](/guide/middleware/compression) doesn't get in the way of assertions. Repeated `set-cookie` headers are available via `res.headers.getSetCookie()`.
+
+For anything taxum-specific (extensions, the `StatusCode` instance, or exact multi-value headers), the underlying
+`HttpResponse` is available as `res.inner`.
+
+::: info Errors become responses
+A router converts thrown errors into error responses, so a failing handler yields a `res` with a 4xx/5xx status
+rather than a rejected promise. Assert on `res.status`; `try`/`catch` is only needed when you invoke a bare service
+without a router.
+:::
+
+## Testing handlers directly
+
+For unit tests that call a handler without a router, build the request with core's builder and wrap the result in
+`TestResponse.from()` to get the same reading interface:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { query } from "@taxum/core/extract";
+import { HttpRequest, jsonResponse } from "@taxum/core/http";
+import { createExtractHandler } from "@taxum/core/routing";
+import { TestResponse } from "@taxum/testing";
+import { z } from "zod";
+
+const myHandler = createExtractHandler(query(z.object({ id: z.string() }))).handler(({ id }) =>
+    jsonResponse({ id }),
+);
+
+test("handler echoes the id", async () => {
+    const req = HttpRequest.builder().uri(new URL("http://localhost/?id=5")).body(null);
+
+    const res = TestResponse.from(await myHandler(req));
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { id: "5" });
+});
+```
+
+`TestResponse.from()` accepts everything a handler may return: an `HttpResponse`, a string, a status/body tuple, and
+so on.
+
+## Configuring the client
+
+The client fills in everything `serve()` would derive from a real connection. All of it is configurable:
+
+```ts
+import { ExtensionKey, Extensions } from "@taxum/core/http";
+import { testClient } from "@taxum/testing";
+
+const CURRENT_USER = new ExtensionKey<{ id: number }>("Current user");
+
+const extensions = new Extensions();
+extensions.insert(CURRENT_USER, { id: 1 });
+
+const client = testClient(router, {
+    baseUri: "https://api.example.com",
+    clientIp: "203.0.113.7",
+    extensions,
+});
+```
+
+- `baseUri` supplies the request URI's protocol, host, and port, plus the injected `host` header. Its path component
+  is ignored; request paths are absolute and must start with `/`. Defaults to `http://localhost/`.
+- `clientIp` becomes the `CONNECT_INFO` extension, so [client-IP middleware](/guide/middleware/client-ip) works
+  unchanged. Defaults to `127.0.0.1`. A per-request override is available as `.clientIp()`.
+- `extensions` is a template of [extensions](/guide/core-concepts/extensions) applied to every request, e.g. to seed
+  a fake auth context instead of running an authentication layer. Per-request `.extension()` calls override it.
+
+The client also injects inert `DISCONNECT_SIGNAL` and `SHUTDOWN_SIGNAL` extensions on every request (see
+[Graceful Shutdown](/guide/core-concepts/graceful-shutdown#disconnect-signal)), so handlers that read them behave
+normally. To test disconnect handling deterministically, pass your own signal:
+
+```ts
+const disconnect = new AbortController();
+
+const res = await client.get("/stream").disconnectSignal(disconnect.signal);
+disconnect.abort();
+```
+
+## Cookies
+
+Every client owns a cookie jar at `client.cookies`, pairing naturally with [`@taxum/cookie`](/guide/addons/cookie)
+on the server side. With `saveCookies: true`, `set-cookie` response headers are captured automatically and matching
+cookies accompany later requests, so session flows test end to end:
+
+```ts
+const client = testClient(router, { saveCookies: true });
+
+await client.post("/login").form({ user: "ben", password: "secret" });
+const res = await client.get("/me");
+
+assert.equal(res.status, 200);
+assert.equal(client.cookies.get("session")?.httpOnly, true);
+```
+
+The jar honors `Path`, `Expires`, and `Max-Age`. It can be seeded and inspected directly, which works regardless of
+`saveCookies` (the option only gates automatic capture):
+
+```ts
+client.cookies.set("session", sessionValue);
+client.cookies.set({ name: "consent", value: "yes", path: "/legal" });
+```
+
+When one client spans multiple tests, `client.cookies.clear()` resets the jar between them.
+
+::: warning Secure cookies need an https base URI
+The jar withholds `Secure` cookies from `http` URIs, just like a real client. With the default
+`http://localhost/` base URI, a `Secure` session cookie is stored but never sent, and every authenticated request
+fails. Use `baseUri: "https://localhost/"` when your app marks its cookies `Secure`.
+:::
+
+## Server-Sent Events
+
+`sseEvents()` consumes an [SSE](/guide/core-concepts/sse) response as an async iterator of `SseEvent` objects. Multi-line `data:` fields are
+reassembled, and `event`, `id`, and `retry` are surfaced:
+
+```ts
+const res = await client.get("/events");
+
+for await (const event of res.sseEvents()) {
+    assert.equal(event.event, "tick");
+    assert.match(event.data ?? "", /Counter/);
+    break;
+}
+```
+
+Breaking out of the loop cancels the response stream, which the handler observes like a client disconnect: an async
+generator's `finally` block runs, and keep-alive timers are cleared. This makes cleanup behavior testable without a
+real socket.
+
+Comment lines, including keep-alive pings, are skipped by default. Pass `{ comments: true }` to assert on them:
+
+```ts
+for await (const event of res.sseEvents({ comments: true })) {
+    // keep-alive pings arrive as { comment: "" }
+}
+```
+
+`sseEvents()` consumes the body as a stream and is therefore mutually exclusive with `text()`/`json()`: whichever is
+used first claims the body.
+
+## What stays outside
+
+The client covers everything behind the `Service` interface, which is where all routing, extraction, and middleware
+lives. A thin layer only runs on a real connection: `trustProxy` handling of `X-Forwarded-*` headers, the
+Host-injection guard, and response framing such as `transfer-encoding: chunked`. That layer is exercised by taxum's
+own test suite, not by yours. If you need to test against that layer explicitly, start a real server with `serve()` on port 0
+and use `fetch`.

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -41,5 +41,8 @@
     },
     "devDependencies": {
         "@taxum/core": "workspace:*"
+    },
+    "dependencies": {
+        "set-cookie-parser": "^3.1.2"
     }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@taxum/testing",
+    "description": "In-process test client for Taxum",
+    "version": "1.0.0",
+    "type": "module",
+    "author": "Ben Scholzen 'DASPRiD'",
+    "license": "BSD-3-Clause",
+    "keywords": [
+        "node",
+        "typescript",
+        "server",
+        "http",
+        "testing",
+        "test-client"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DASPRiD/taxum.git"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.build.json",
+        "test": "tsx -C taxum --test --test-reporter=spec",
+        "test:ci": "pnpm test",
+        "typecheck": "tsc --noEmit"
+    },
+    "files": [
+        "dist/**/*"
+    ],
+    "exports": {
+        ".": {
+            "types": [
+                "./dist/index.d.ts",
+                "./src/index.ts"
+            ],
+            "taxum": "./src/index.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "peerDependencies": {
+        "@taxum/core": "workspace:^"
+    },
+    "devDependencies": {
+        "@taxum/core": "workspace:*"
+    }
+}

--- a/packages/testing/src/client.ts
+++ b/packages/testing/src/client.ts
@@ -1,0 +1,136 @@
+import type { SocketAddress } from "node:net";
+import { Extensions, Method } from "@taxum/core/http";
+import type { HttpService } from "@taxum/core/service";
+import {
+    type ResolvedTestClientOptions,
+    type TestRequest,
+    TestRequestBuilder,
+    toSocketAddress,
+} from "./request.js";
+
+/**
+ * Options for creating a {@link TestClient}.
+ */
+export type TestClientOptions = {
+    /**
+     * Base URI request paths are resolved against.
+     *
+     * Supplies the request URI's protocol, host, and port as well as the
+     * injected `host` header, mirroring what `serve()` derives from the
+     * connection and the `Host` header. A path component is ignored:
+     * request paths are absolute and must start with `/`.
+     *
+     * Defaults to `http://localhost/`.
+     */
+    baseUri?: URL | string;
+
+    /**
+     * Client address stored as the `CONNECT_INFO` extension on every
+     * request.
+     *
+     * Defaults to `127.0.0.1`.
+     */
+    clientIp?: string | SocketAddress;
+
+    /**
+     * Extensions inserted into every request, e.g. a fake auth context.
+     *
+     * The instance acts as a template: each request gets a fresh
+     * {@link Extensions} populated from it, so inserts made during one
+     * request don't leak into the next. The extension values themselves are
+     * shared by reference across requests; prefer immutable values. Per-
+     * request extensions override these.
+     */
+    extensions?: Extensions;
+};
+
+/**
+ * An in-process test client for a taxum service.
+ *
+ * Requests run through `service.invoke()` without a socket, exercising the
+ * full stack of routes, extractors, and layers. Everything `serve()` would
+ * inject on a real connection is supplied by the client: a `host` header
+ * derived from `baseUri`, the `CONNECT_INFO` extension, and inert
+ * `DISCONNECT_SIGNAL` / `SHUTDOWN_SIGNAL` extensions, so handler code
+ * reading them behaves as in production.
+ *
+ * ```ts
+ * const client = testClient(router);
+ * const res = await client.get("/users/5");
+ *
+ * assert.equal(res.status, 200);
+ * assert.deepEqual(await res.json(), { id: "5" });
+ * ```
+ */
+export class TestClient {
+    private readonly service: HttpService;
+    private readonly clientOptions: ResolvedTestClientOptions;
+
+    public constructor(service: HttpService, options?: TestClientOptions) {
+        this.service = service;
+        this.clientOptions = {
+            baseUri: new URL(options?.baseUri ?? "http://localhost/"),
+            clientIp: toSocketAddress(options?.clientIp ?? "127.0.0.1"),
+            extensions: options?.extensions ?? new Extensions(),
+        };
+    }
+
+    /**
+     * Creates a GET request for the given path.
+     */
+    public get(path: string): TestRequest {
+        return this.request(Method.GET, path);
+    }
+
+    /**
+     * Creates a POST request for the given path.
+     */
+    public post(path: string): TestRequest {
+        return this.request(Method.POST, path);
+    }
+
+    /**
+     * Creates a PUT request for the given path.
+     */
+    public put(path: string): TestRequest {
+        return this.request(Method.PUT, path);
+    }
+
+    /**
+     * Creates a PATCH request for the given path.
+     */
+    public patch(path: string): TestRequest {
+        return this.request(Method.PATCH, path);
+    }
+
+    /**
+     * Creates a DELETE request for the given path.
+     */
+    public delete(path: string): TestRequest {
+        return this.request(Method.DELETE, path);
+    }
+
+    /**
+     * Creates a HEAD request for the given path.
+     */
+    public head(path: string): TestRequest {
+        return this.request(Method.HEAD, path);
+    }
+
+    /**
+     * Creates an OPTIONS request for the given path.
+     */
+    public options(path: string): TestRequest {
+        return this.request(Method.OPTIONS, path);
+    }
+
+    private request(method: Method, path: string): TestRequest {
+        return new TestRequestBuilder(this.service, method, path, this.clientOptions);
+    }
+}
+
+/**
+ * Creates a new {@link TestClient} for the given service.
+ */
+export const testClient = (service: HttpService, options?: TestClientOptions): TestClient =>
+    new TestClient(service, options);

--- a/packages/testing/src/client.ts
+++ b/packages/testing/src/client.ts
@@ -1,6 +1,7 @@
 import type { SocketAddress } from "node:net";
 import { Extensions, Method } from "@taxum/core/http";
 import type { HttpService } from "@taxum/core/service";
+import { TestCookieJar } from "./jar.js";
 import {
     type ResolvedTestClientOptions,
     type TestRequest,
@@ -42,6 +43,17 @@ export type TestClientOptions = {
      * request extensions override these.
      */
     extensions?: Extensions;
+
+    /**
+     * Automatically captures `set-cookie` response headers into
+     * {@link TestClient.cookies}.
+     *
+     * Only capture is gated by this option: the jar always sends whatever
+     * it holds, and stays available for seeding and inspection. Note that
+     * `Secure` cookies are withheld unless `baseUri` uses `https`. Defaults
+     * to `false`.
+     */
+    saveCookies?: boolean;
 };
 
 /**
@@ -63,6 +75,15 @@ export type TestClientOptions = {
  * ```
  */
 export class TestClient {
+    /**
+     * The client's cookie jar.
+     *
+     * Cookies stored here accompany matching requests regardless of the
+     * `saveCookies` option; responses only populate it when `saveCookies`
+     * is enabled.
+     */
+    public readonly cookies = new TestCookieJar();
+
     private readonly service: HttpService;
     private readonly clientOptions: ResolvedTestClientOptions;
 
@@ -72,6 +93,8 @@ export class TestClient {
             baseUri: new URL(options?.baseUri ?? "http://localhost/"),
             clientIp: toSocketAddress(options?.clientIp ?? "127.0.0.1"),
             extensions: options?.extensions ?? new Extensions(),
+            cookies: this.cookies,
+            saveCookies: options?.saveCookies ?? false,
         };
     }
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -5,5 +5,6 @@
  */
 
 export * from "./client.js";
+export { type JarCookie, type SeedCookie, TestCookieJar } from "./jar.js";
 export type { FormInput, QueryInput, QueryValue, TestRequest } from "./request.js";
 export { TestResponse } from "./response.js";

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * In-process test client for taxum services.
+ *
+ * @packageDocumentation
+ */
+
+export * from "./client.js";
+export type { FormInput, QueryInput, QueryValue, TestRequest } from "./request.js";
+export { TestResponse } from "./response.js";

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -7,4 +7,4 @@
 export * from "./client.js";
 export { type JarCookie, type SeedCookie, TestCookieJar } from "./jar.js";
 export type { FormInput, QueryInput, QueryValue, TestRequest } from "./request.js";
-export { TestResponse } from "./response.js";
+export { type SseEventsOptions, TestResponse } from "./response.js";

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -6,5 +6,12 @@
 
 export * from "./client.js";
 export { type JarCookie, type SeedCookie, TestCookieJar } from "./jar.js";
-export type { FormInput, QueryInput, QueryValue, TestRequest } from "./request.js";
+export type {
+    FormInput,
+    QueryInput,
+    QueryValue,
+    TestRequest,
+    TestRequestBodySetters,
+    TestRequestPromise,
+} from "./request.js";
 export { type SseEventsOptions, TestResponse } from "./response.js";

--- a/packages/testing/src/jar.ts
+++ b/packages/testing/src/jar.ts
@@ -89,6 +89,9 @@ export class TestCookieJar {
     public set(name: string, value: string): void;
     public set(cookie: SeedCookie): void;
     public set(cookieOrName: string | SeedCookie, value?: string): void {
+        // The overloads guarantee `value` is present with a string name; the fallback only
+        // guards untyped calls.
+        /* node:coverage ignore next 4 */
         const seed: SeedCookie =
             typeof cookieOrName === "string"
                 ? { name: cookieOrName, value: value ?? "" }

--- a/packages/testing/src/jar.ts
+++ b/packages/testing/src/jar.ts
@@ -263,6 +263,7 @@ const resolvePath = (cookiePath: string | undefined, requestUri: URL): string =>
 const defaultPath = (requestUri: URL): string => {
     const path = requestUri.pathname;
 
+    /* node:coverage ignore next 3 */
     if (path === "" || !path.startsWith("/")) {
         return "/";
     }

--- a/packages/testing/src/jar.ts
+++ b/packages/testing/src/jar.ts
@@ -1,0 +1,287 @@
+import { parseSetCookie } from "set-cookie-parser";
+
+/**
+ * A cookie stored in a {@link TestCookieJar}.
+ *
+ * Mirrors the attributes of the `set-cookie` header the cookie was ingested
+ * from, so tests can assert on them directly.
+ */
+export type JarCookie = {
+    name: string;
+    /**
+     * The raw cookie value, exactly as the server sent it (no decoding).
+     */
+    value: string;
+    /**
+     * The cookie's path; defaults to the RFC 6265 default-path of the
+     * request that received it, or `/` for manually seeded cookies.
+     */
+    path: string;
+    /**
+     * Whether the cookie carried the `Secure` attribute; `false` when
+     * absent, so both assertion directions compare cleanly.
+     */
+    secure: boolean;
+    /**
+     * Whether the cookie carried the `HttpOnly` attribute; `false` when
+     * absent. Informational only: the jar sends `HttpOnly` cookies like any
+     * other, as it is not a browser-script context.
+     */
+    httpOnly: boolean;
+    expires?: Date;
+    maxAge?: number;
+    domain?: string;
+    sameSite?: string;
+};
+
+/**
+ * Input accepted by {@link TestCookieJar.set}'s object form: a
+ * {@link JarCookie} whose `path` (default `/`), `secure`, and `httpOnly`
+ * (default `false`) may be omitted.
+ */
+export type SeedCookie = Omit<JarCookie, "path" | "secure" | "httpOnly"> & {
+    path?: string;
+    secure?: boolean;
+    httpOnly?: boolean;
+};
+
+type StoredCookie = {
+    cookie: JarCookie;
+    /**
+     * Absolute expiry timestamp resolved at ingest time (`max-age` wins over
+     * `expires`, per RFC 6265); `null` for session cookies.
+     */
+    expiresAt: number | null;
+};
+
+/**
+ * A client-side cookie jar for a {@link TestClient}.
+ *
+ * Stores cookies from `set-cookie` response headers (when the client's
+ * `saveCookies` option is enabled) and decides which of them accompany each
+ * request. `Path`, `Expires`, and `Max-Age` are honored. `Secure` cookies
+ * are only sent when the client's base URI uses `https` — with the default
+ * `http://localhost/` base URI they are stored but withheld. `Domain` is
+ * ignored (the client only ever talks to one host) and so is `HttpOnly`
+ * (the jar is not a browser-script context).
+ *
+ * The jar can be seeded and inspected directly, independently of
+ * `saveCookies`, which only gates automatic capture:
+ *
+ * ```ts
+ * client.cookies.set("session", sessionValue);
+ * assert.equal(client.cookies.get("session")?.value, sessionValue);
+ * ```
+ *
+ * Cookies are keyed by name and path, mirroring how user agents replace
+ * cookies. Values are stored and sent verbatim; no percent-decoding or
+ * -encoding is applied.
+ */
+export class TestCookieJar {
+    private readonly cookies = new Map<string, StoredCookie>();
+
+    /**
+     * Stores a cookie.
+     *
+     * The shorthand form seeds a session cookie with path `/`; the object
+     * form allows setting attributes.
+     */
+    public set(name: string, value: string): void;
+    public set(cookie: SeedCookie): void;
+    public set(cookieOrName: string | SeedCookie, value?: string): void {
+        const seed: SeedCookie =
+            typeof cookieOrName === "string"
+                ? { name: cookieOrName, value: value ?? "" }
+                : cookieOrName;
+
+        this.store({
+            ...seed,
+            path: seed.path ?? "/",
+            secure: seed.secure ?? false,
+            httpOnly: seed.httpOnly ?? false,
+        });
+    }
+
+    /**
+     * Returns the live cookie with the given name, or `null`.
+     *
+     * When the same name exists at multiple paths, the cookie with the
+     * longest (most specific) path is returned.
+     */
+    public get(name: string): JarCookie | null {
+        this.purgeExpired();
+
+        let bestMatch: JarCookie | null = null;
+
+        for (const { cookie } of this.cookies.values()) {
+            if (
+                cookie.name === name &&
+                (bestMatch === null || cookie.path.length > bestMatch.path.length)
+            ) {
+                bestMatch = cookie;
+            }
+        }
+
+        return bestMatch;
+    }
+
+    /**
+     * Removes all cookies with the given name, across all paths.
+     */
+    public delete(name: string): void {
+        for (const [key, { cookie }] of this.cookies.entries()) {
+            if (cookie.name === name) {
+                this.cookies.delete(key);
+            }
+        }
+    }
+
+    /**
+     * Removes all cookies.
+     */
+    public clear(): void {
+        this.cookies.clear();
+    }
+
+    /**
+     * Iterates over all live cookies.
+     */
+    public *[Symbol.iterator](): IterableIterator<JarCookie> {
+        this.purgeExpired();
+
+        for (const { cookie } of this.cookies.values()) {
+            yield cookie;
+        }
+    }
+
+    /**
+     * Stores a cookie from a raw `set-cookie` header, as if it had been
+     * received in a response to a request for `requestUri`.
+     *
+     * Used by the client to capture response cookies; call it directly to
+     * seed the jar from a captured header string. An already-expired cookie
+     * (e.g. `Max-Age=0`) removes the matching stored cookie, mirroring how
+     * servers delete cookies. Malformed headers are ignored.
+     */
+    public ingest(setCookieHeader: string, requestUri: URL): void {
+        const parsed = parseSetCookie(setCookieHeader, { decodeValues: false, split: false })[0];
+
+        if (!parsed || parsed.name === "") {
+            return;
+        }
+
+        this.store({
+            name: parsed.name,
+            value: parsed.value,
+            path: resolvePath(parsed.path, requestUri),
+            secure: parsed.secure ?? false,
+            httpOnly: parsed.httpOnly ?? false,
+            expires: parsed.expires,
+            maxAge: parsed.maxAge,
+            domain: parsed.domain,
+            sameSite: parsed.sameSite,
+        });
+    }
+
+    /**
+     * Returns the cookies the jar would send with a request to the given
+     * URI, longest path first.
+     */
+    public cookiesFor(requestUri: URL): JarCookie[] {
+        this.purgeExpired();
+
+        const matching: JarCookie[] = [];
+
+        for (const { cookie } of this.cookies.values()) {
+            if (cookie.secure && requestUri.protocol !== "https:") {
+                continue;
+            }
+
+            if (pathMatches(cookie.path, requestUri.pathname)) {
+                matching.push(cookie);
+            }
+        }
+
+        return matching.sort((a, b) => b.path.length - a.path.length);
+    }
+
+    private store(cookie: JarCookie): void {
+        // NUL cannot appear in a parsed cookie name or path, making the key collision-free.
+        const key = `${cookie.name}\0${cookie.path}`;
+        const expiresAt = resolveExpiry(cookie);
+
+        if (expiresAt !== null && expiresAt <= Date.now()) {
+            this.cookies.delete(key);
+            return;
+        }
+
+        this.cookies.set(key, { cookie, expiresAt });
+    }
+
+    private purgeExpired(): void {
+        const now = Date.now();
+
+        for (const [key, { expiresAt }] of this.cookies.entries()) {
+            if (expiresAt !== null && expiresAt <= now) {
+                this.cookies.delete(key);
+            }
+        }
+    }
+}
+
+const resolveExpiry = (cookie: JarCookie): number | null => {
+    if (cookie.maxAge !== undefined) {
+        return Date.now() + cookie.maxAge * 1000;
+    }
+
+    if (cookie.expires !== undefined) {
+        const timestamp = cookie.expires.getTime();
+
+        // A malformed Expires parses to an Invalid Date; RFC 6265 says to
+        // ignore the attribute, making it a session cookie.
+        return Number.isNaN(timestamp) ? null : timestamp;
+    }
+
+    return null;
+};
+
+/**
+ * RFC 6265 §5.2.4: an empty `Path` or one not starting with `/` falls back
+ * to the request's default-path.
+ */
+const resolvePath = (cookiePath: string | undefined, requestUri: URL): string => {
+    if (cookiePath?.startsWith("/")) {
+        return cookiePath;
+    }
+
+    return defaultPath(requestUri);
+};
+
+/**
+ * RFC 6265 §5.1.4 default-path: the request path's directory.
+ */
+const defaultPath = (requestUri: URL): string => {
+    const path = requestUri.pathname;
+
+    if (path === "" || !path.startsWith("/")) {
+        return "/";
+    }
+
+    const lastSlash = path.lastIndexOf("/");
+    return lastSlash === 0 ? "/" : path.slice(0, lastSlash);
+};
+
+/**
+ * RFC 6265 §5.1.4 path-match.
+ */
+const pathMatches = (cookiePath: string, requestPath: string): boolean => {
+    if (cookiePath === requestPath) {
+        return true;
+    }
+
+    if (!requestPath.startsWith(cookiePath)) {
+        return false;
+    }
+
+    return cookiePath.endsWith("/") || requestPath[cookiePath.length] === "/";
+};

--- a/packages/testing/src/jar.ts
+++ b/packages/testing/src/jar.ts
@@ -108,24 +108,47 @@ export class TestCookieJar {
     /**
      * Returns the live cookie with the given name, or `null`.
      *
-     * When the same name exists at multiple paths, the cookie with the
-     * longest (most specific) path is returned.
+     * With `path` given, only the cookie whose `Path` attribute equals it
+     * exactly is returned (request-path matching is
+     * {@link TestCookieJar.cookiesFor}'s job).
+     *
+     * @throws {@link !Error} if the name exists at multiple paths and no
+     *         `path` was given; asserting against an arbitrary one of them
+     *         would make the test outcome a coin flip.
      */
-    public get(name: string): JarCookie | null {
+    public get(name: string, path?: string): JarCookie | null {
         this.purgeExpired();
 
-        let bestMatch: JarCookie | null = null;
+        const matches: JarCookie[] = [];
 
         for (const { cookie } of this.cookies.values()) {
-            if (
-                cookie.name === name &&
-                (bestMatch === null || cookie.path.length > bestMatch.path.length)
-            ) {
-                bestMatch = cookie;
+            if (cookie.name !== name) {
+                continue;
             }
+
+            if (path !== undefined) {
+                if (cookie.path === path) {
+                    return cookie;
+                }
+
+                continue;
+            }
+
+            matches.push(cookie);
         }
 
-        return bestMatch;
+        if (path !== undefined) {
+            return null;
+        }
+
+        if (matches.length > 1) {
+            const paths = matches.map((cookie) => `"${cookie.path}"`).join(", ");
+            throw new Error(
+                `Multiple cookies named "${name}" (paths ${paths}); pass a path to disambiguate`,
+            );
+        }
+
+        return matches[0] ?? null;
     }
 
     /**

--- a/packages/testing/src/request.ts
+++ b/packages/testing/src/request.ts
@@ -1,0 +1,408 @@
+import { SocketAddress } from "node:net";
+import {
+    Body,
+    type BodyLike,
+    CONNECT_INFO,
+    type ExtensionKey,
+    Extensions,
+    type HeaderEntryLike,
+    HeaderMap,
+    type HeaderValueLike,
+    HttpRequest,
+    type HttpResponse,
+    Method,
+    StatusCode,
+} from "@taxum/core/http";
+import { DISCONNECT_SIGNAL, SHUTDOWN_SIGNAL } from "@taxum/core/server";
+import type { HttpService } from "@taxum/core/service";
+import { TestResponse } from "./response.js";
+
+/**
+ * A single value accepted by {@link TestRequest.query} and
+ * {@link TestRequest.form} records.
+ */
+export type QueryValue = string | number | boolean;
+
+/**
+ * Input accepted by {@link TestRequest.form}: a flat record (arrays become
+ * repeated keys) or a {@link !URLSearchParams} instance.
+ */
+export type FormInput = Record<string, QueryValue | QueryValue[]> | URLSearchParams;
+
+/**
+ * Input accepted by {@link TestRequest.query}: everything {@link FormInput}
+ * allows, plus a raw query string for wire formats the flat encoding cannot
+ * express (e.g. nested bracket syntax).
+ */
+export type QueryInput = FormInput | string;
+
+type TestRequestPromise = {
+    readonly [Symbol.toStringTag]: string;
+    then<TFulfilled = TestResponse, TRejected = never>(
+        onFulfilled?: ((value: TestResponse) => TFulfilled | PromiseLike<TFulfilled>) | null,
+        onRejected?: ((reason: unknown) => TRejected | PromiseLike<TRejected>) | null,
+    ): Promise<TFulfilled | TRejected>;
+    catch<TRejected = never>(
+        onRejected?: ((reason: unknown) => TRejected | PromiseLike<TRejected>) | null,
+    ): Promise<TestResponse | TRejected>;
+    finally(onFinally?: (() => void) | null): Promise<TestResponse>;
+};
+
+type TestRequestBodySetters = {
+    /**
+     * Sets a JSON body, implying a `content-type` of `application/json`.
+     */
+    json(value: unknown): TestRequest<true>;
+
+    /**
+     * Sets a URL-encoded form body, implying a `content-type` of
+     * `application/x-www-form-urlencoded`.
+     */
+    form(input: FormInput): TestRequest<true>;
+
+    /**
+     * Sets a raw body.
+     *
+     * No `content-type` is implied; set one via
+     * {@link TestRequest.header} if the handler needs it.
+     */
+    body(body: BodyLike): TestRequest<true>;
+};
+
+/**
+ * A pending test request.
+ *
+ * The request is thenable: awaiting it sends it and yields a
+ * {@link TestResponse}. The send happens exactly once; awaiting again yields
+ * the same response, and calling any setter after the send throws.
+ *
+ * `BodySet` tracks whether a body setter has been called: once it flips to
+ * `true`, the body setters disappear from the type, so setting two bodies
+ * does not type-check.
+ */
+export type TestRequest<BodySet extends boolean = false> = TestRequestPromise & {
+    /**
+     * Appends a header to the request.
+     *
+     * An explicit `content-type` header always wins over the one implied by
+     * {@link TestRequest.json} or {@link TestRequest.form}.
+     */
+    header(key: string, value: HeaderValueLike): TestRequest<BodySet>;
+
+    /**
+     * Appends multiple headers to the request.
+     */
+    headers(headers: HeaderMap | Iterable<HeaderEntryLike>): TestRequest<BodySet>;
+
+    /**
+     * Appends query parameters to the request URI.
+     *
+     * Parameters merge with any query string already present in the path and
+     * with previous `query()` calls.
+     *
+     * All input is normalized through {@link !URLSearchParams}; raw strings
+     * are re-encoded, not preserved byte-for-byte.
+     */
+    query(input: QueryInput): TestRequest<BodySet>;
+
+    /**
+     * Adds a cookie to the request's `cookie` header.
+     */
+    cookie(name: string, value: string): TestRequest<BodySet>;
+
+    /**
+     * Inserts an extension into the request.
+     *
+     * Per-request extensions override client-level extensions and the
+     * client's built-in defaults ({@link CONNECT_INFO},
+     * {@link DISCONNECT_SIGNAL}, {@link SHUTDOWN_SIGNAL}).
+     */
+    extension<T>(key: ExtensionKey<T>, value: T): TestRequest<BodySet>;
+
+    /**
+     * Overrides the {@link CONNECT_INFO} extension for this request.
+     */
+    clientIp(clientIp: string | SocketAddress): TestRequest<BodySet>;
+
+    /**
+     * Overrides the {@link DISCONNECT_SIGNAL} extension for this request.
+     *
+     * Aborting the supplied signal simulates a client disconnect
+     * deterministically, e.g. mid-stream for SSE handlers.
+     */
+    disconnectSignal(signal: AbortSignal): TestRequest<BodySet>;
+    // `unknown` is the intersection identity (`T & unknown` is `T`), adding no members.
+} & (BodySet extends true ? unknown : TestRequestBodySetters);
+
+export type ResolvedTestClientOptions = {
+    baseUri: URL;
+    clientIp: SocketAddress;
+    extensions: Extensions;
+};
+
+export class TestRequestBuilder implements TestRequest {
+    public readonly [Symbol.toStringTag] = "TestRequest";
+
+    private readonly service: HttpService;
+    private readonly clientOptions: ResolvedTestClientOptions;
+    private readonly requestMethod: Method;
+    private readonly uri: URL;
+    private readonly requestHeaders = new HeaderMap();
+    private readonly requestExtensions = new Extensions();
+    private readonly cookiePairs: [string, string][] = [];
+    private requestBody: Body | null = null;
+    private impliedContentType: string | null = null;
+    private response: Promise<TestResponse> | null = null;
+
+    public constructor(
+        service: HttpService,
+        method: Method,
+        path: string,
+        clientOptions: ResolvedTestClientOptions,
+    ) {
+        if (!path.startsWith("/") || path.startsWith("//")) {
+            throw new Error(`Request path must start with a single "/", got: ${path}`);
+        }
+
+        this.service = service;
+        this.clientOptions = clientOptions;
+        this.requestMethod = method;
+        this.uri = new URL(path, clientOptions.baseUri);
+        // A URI fragment never reaches a server; production requests cannot carry one.
+        this.uri.hash = "";
+    }
+
+    public header(key: string, value: HeaderValueLike): this {
+        this.assertUnsent();
+        this.requestHeaders.append(key, value);
+        return this;
+    }
+
+    public headers(headers: HeaderMap | Iterable<HeaderEntryLike>): this {
+        this.assertUnsent();
+
+        const map = headers instanceof HeaderMap ? headers : HeaderMap.from(headers);
+
+        for (const [name, value] of map) {
+            this.requestHeaders.append(name, value);
+        }
+
+        return this;
+    }
+
+    public query(input: QueryInput): this {
+        this.assertUnsent();
+
+        for (const [name, value] of toSearchParams(input)) {
+            this.uri.searchParams.append(name, value);
+        }
+
+        return this;
+    }
+
+    public cookie(name: string, value: string): this {
+        this.assertUnsent();
+        this.cookiePairs.push([name, value]);
+        return this;
+    }
+
+    public extension<T>(key: ExtensionKey<T>, value: T): this {
+        this.assertUnsent();
+        this.requestExtensions.insert(key, value);
+        return this;
+    }
+
+    public clientIp(clientIp: string | SocketAddress): this {
+        this.assertUnsent();
+        this.requestExtensions.insert(CONNECT_INFO, toSocketAddress(clientIp));
+        return this;
+    }
+
+    public disconnectSignal(signal: AbortSignal): this {
+        this.assertUnsent();
+        this.requestExtensions.insert(DISCONNECT_SIGNAL, signal);
+        return this;
+    }
+
+    public json(value: unknown): TestRequest<true> {
+        const serialized = JSON.stringify(value);
+
+        if (serialized === undefined) {
+            throw new Error("Value is not JSON-serializable");
+        }
+
+        return this.setBody(Body.from(serialized), "application/json");
+    }
+
+    public form(input: FormInput): TestRequest<true> {
+        return this.setBody(
+            Body.from(toSearchParams(input).toString()),
+            "application/x-www-form-urlencoded",
+        );
+    }
+
+    public body(body: BodyLike): TestRequest<true> {
+        return this.setBody(Body.from(body), null);
+    }
+
+    // biome-ignore lint/suspicious/noThenProperty: the request is intentionally thenable
+    public then<TFulfilled = TestResponse, TRejected = never>(
+        onFulfilled?: ((value: TestResponse) => TFulfilled | PromiseLike<TFulfilled>) | null,
+        onRejected?: ((reason: unknown) => TRejected | PromiseLike<TRejected>) | null,
+    ): Promise<TFulfilled | TRejected> {
+        return this.send().then(onFulfilled, onRejected);
+    }
+
+    public catch<TRejected = never>(
+        onRejected?: ((reason: unknown) => TRejected | PromiseLike<TRejected>) | null,
+    ): Promise<TestResponse | TRejected> {
+        return this.send().catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<TestResponse> {
+        return this.send().finally(onFinally);
+    }
+
+    private setBody(body: Body, impliedContentType: string | null): TestRequest<true> {
+        this.assertUnsent();
+
+        if (this.requestBody !== null) {
+            throw new Error("Request body has already been set");
+        }
+
+        this.requestBody = body;
+        this.impliedContentType = impliedContentType;
+        return this;
+    }
+
+    private assertUnsent(): void {
+        if (this.response !== null) {
+            throw new Error("Request has already been sent");
+        }
+    }
+
+    private send(): Promise<TestResponse> {
+        this.response ??= this.dispatch();
+        return this.response;
+    }
+
+    private async dispatch(): Promise<TestResponse> {
+        const headers = new HeaderMap(this.requestHeaders);
+
+        if (!headers.containsKey("host")) {
+            headers.insert("host", this.uri.host);
+        }
+
+        if (this.impliedContentType !== null && !headers.containsKey("content-type")) {
+            headers.insert("content-type", this.impliedContentType);
+        }
+
+        if (this.requestBody !== null && !headers.containsKey("content-length")) {
+            const exactSize = this.requestBody.sizeHint.exact();
+
+            if (exactSize !== null) {
+                headers.insert("content-length", exactSize.toString());
+            }
+        }
+
+        if (this.cookiePairs.length > 0) {
+            const values = [
+                ...headers.getAll("cookie").map((value) => value.value),
+                ...this.cookiePairs.map(([name, value]) => `${name}=${value}`),
+            ];
+            headers.insert("cookie", values.join("; "));
+        }
+
+        const extensions = new Extensions();
+        extensions.insert(CONNECT_INFO, this.clientOptions.clientIp);
+        extensions.insert(DISCONNECT_SIGNAL, new AbortController().signal);
+        extensions.insert(SHUTDOWN_SIGNAL, new AbortController().signal);
+        extensions.extend(this.clientOptions.extensions);
+        extensions.extend(this.requestExtensions);
+
+        const request = HttpRequest.builder()
+            .method(this.requestMethod)
+            .uri(this.uri)
+            .headers(headers)
+            .extensions(extensions)
+            .body(this.requestBody);
+
+        const response = await this.service.invoke(request);
+        normalizeResponse(this.requestMethod, response);
+        return TestResponse.from(response);
+    }
+}
+
+export const toSocketAddress = (input: string | SocketAddress): SocketAddress => {
+    if (input instanceof SocketAddress) {
+        return input;
+    }
+
+    return new SocketAddress({
+        address: input,
+        family: input.includes(":") ? "ipv6" : "ipv4",
+    });
+};
+
+const toSearchParams = (input: QueryInput): URLSearchParams => {
+    if (input instanceof URLSearchParams) {
+        return input;
+    }
+
+    if (typeof input === "string") {
+        return new URLSearchParams(input);
+    }
+
+    const params = new URLSearchParams();
+
+    for (const [name, value] of Object.entries(input)) {
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                params.append(name, item.toString());
+            }
+        } else {
+            params.append(name, value.toString());
+        }
+    }
+
+    return params;
+};
+
+/**
+ * Applies the normalization a response undergoes on the wire.
+ *
+ * The route layer only strips HEAD/1xx/204/304 bodies for top-level matched
+ * routes; for 405s, default 404s, and non-Router services, production relies
+ * on Node's `ServerResponse` to do it. `invoke()` has no `ServerResponse`,
+ * so this pass closes the gap. It is idempotent for responses the route
+ * layer already normalized.
+ *
+ * No `content-length` is added: responses without one go out chunked in
+ * production, so inventing the header here would let tests assert framing
+ * the wire never carries.
+ */
+const normalizeResponse = (method: Method, res: HttpResponse): void => {
+    if (isBodyless(res.status)) {
+        res.headers.remove("content-length");
+        res.headers.remove("transfer-encoding");
+        discardBody(res);
+        return;
+    }
+
+    if (method.equals(Method.HEAD)) {
+        discardBody(res);
+    }
+};
+
+const isBodyless = (status: StatusCode): boolean =>
+    status.isInformational() ||
+    status.code === StatusCode.NO_CONTENT.code ||
+    status.code === StatusCode.NOT_MODIFIED.code;
+
+const discardBody = (res: HttpResponse): void => {
+    res.body.readable.cancel().catch(() => {
+        // Errors from a discarded body are of no interest.
+    });
+
+    res.body = Body.from(null);
+};

--- a/packages/testing/src/request.ts
+++ b/packages/testing/src/request.ts
@@ -19,25 +19,29 @@ import type { TestCookieJar } from "./jar.js";
 import { TestResponse } from "./response.js";
 
 /**
- * A single value accepted by {@link TestRequest.query} and
- * {@link TestRequest.form} records.
+ * A single value accepted by `query()` and
+ * `form()` records.
  */
 export type QueryValue = string | number | boolean;
 
 /**
- * Input accepted by {@link TestRequest.form}: a flat record (arrays become
+ * Input accepted by `form()`: a flat record (arrays become
  * repeated keys) or a {@link !URLSearchParams} instance.
  */
 export type FormInput = Record<string, QueryValue | QueryValue[]> | URLSearchParams;
 
 /**
- * Input accepted by {@link TestRequest.query}: everything {@link FormInput}
+ * Input accepted by `query()`: everything {@link FormInput}
  * allows, plus a raw query string for wire formats the flat encoding cannot
  * express (e.g. nested bracket syntax).
  */
 export type QueryInput = FormInput | string;
 
-type TestRequestPromise = {
+/**
+ * The promise surface of a {@link TestRequest}: awaiting sends the request
+ * and yields a {@link TestResponse}.
+ */
+export type TestRequestPromise = {
     readonly [Symbol.toStringTag]: string;
     then<TFulfilled = TestResponse, TRejected = never>(
         onFulfilled?: ((value: TestResponse) => TFulfilled | PromiseLike<TFulfilled>) | null,
@@ -49,7 +53,13 @@ type TestRequestPromise = {
     finally(onFinally?: (() => void) | null): Promise<TestResponse>;
 };
 
-type TestRequestBodySetters = {
+/**
+ * The body setters of a {@link TestRequest}.
+ *
+ * Only present while no body has been set: each returns
+ * `TestRequest<true>`, on which all three are gone.
+ */
+export type TestRequestBodySetters = {
     /**
      * Sets a JSON body, implying a `content-type` of `application/json`.
      */
@@ -65,7 +75,7 @@ type TestRequestBodySetters = {
      * Sets a raw body.
      *
      * No `content-type` is implied; set one via
-     * {@link TestRequest.header} if the handler needs it.
+     * `header()` if the handler needs it.
      */
     body(body: BodyLike): TestRequest<true>;
 };
@@ -86,7 +96,7 @@ export type TestRequest<BodySet extends boolean = false> = TestRequestPromise & 
      * Appends a header to the request.
      *
      * An explicit `content-type` header always wins over the one implied by
-     * {@link TestRequest.json} or {@link TestRequest.form}.
+     * `json()` or `form()`.
      */
     header(key: string, value: HeaderValueLike): TestRequest<BodySet>;
 

--- a/packages/testing/src/request.ts
+++ b/packages/testing/src/request.ts
@@ -15,6 +15,7 @@ import {
 } from "@taxum/core/http";
 import { DISCONNECT_SIGNAL, SHUTDOWN_SIGNAL } from "@taxum/core/server";
 import type { HttpService } from "@taxum/core/service";
+import type { TestCookieJar } from "./jar.js";
 import { TestResponse } from "./response.js";
 
 /**
@@ -107,6 +108,9 @@ export type TestRequest<BodySet extends boolean = false> = TestRequestPromise & 
 
     /**
      * Adds a cookie to the request's `cookie` header.
+     *
+     * Sent in addition to any matching jar cookies; a duplicate name is
+     * emitted twice (jar first), which RFC 6265 permits.
      */
     cookie(name: string, value: string): TestRequest<BodySet>;
 
@@ -138,6 +142,8 @@ export type ResolvedTestClientOptions = {
     baseUri: URL;
     clientIp: SocketAddress;
     extensions: Extensions;
+    cookies: TestCookieJar;
+    saveCookies: boolean;
 };
 
 export class TestRequestBuilder implements TestRequest {
@@ -305,12 +311,16 @@ export class TestRequestBuilder implements TestRequest {
             }
         }
 
-        if (this.cookiePairs.length > 0) {
-            const values = [
-                ...headers.getAll("cookie").map((value) => value.value),
-                ...this.cookiePairs.map(([name, value]) => `${name}=${value}`),
-            ];
-            headers.insert("cookie", values.join("; "));
+        const cookieValues = [
+            ...this.clientOptions.cookies
+                .cookiesFor(this.uri)
+                .map((cookie) => `${cookie.name}=${cookie.value}`),
+            ...headers.getAll("cookie").map((value) => value.value),
+            ...this.cookiePairs.map(([name, value]) => `${name}=${value}`),
+        ];
+
+        if (cookieValues.length > 0) {
+            headers.insert("cookie", cookieValues.join("; "));
         }
 
         const extensions = new Extensions();
@@ -328,6 +338,13 @@ export class TestRequestBuilder implements TestRequest {
             .body(this.requestBody);
 
         const response = await this.service.invoke(request);
+
+        if (this.clientOptions.saveCookies) {
+            for (const setCookie of response.headers.getAll("set-cookie")) {
+                this.clientOptions.cookies.ingest(setCookie.value, this.uri);
+            }
+        }
+
         normalizeResponse(this.requestMethod, response);
         return TestResponse.from(response);
     }

--- a/packages/testing/src/response.ts
+++ b/packages/testing/src/response.ts
@@ -2,11 +2,24 @@ import consumers from "node:stream/consumers";
 import { promisify } from "node:util";
 import zlib from "node:zlib";
 import { HttpResponse, type HttpResponseLike } from "@taxum/core/http";
+import type { SseEvent } from "@taxum/core/sse";
 
 const gunzip = promisify(zlib.gunzip);
 const inflate = promisify(zlib.inflate);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 const zstdDecompress = "zstdDecompress" in zlib ? promisify(zlib.zstdDecompress) : null;
+
+/**
+ * Options for {@link TestResponse.sseEvents}.
+ */
+export type SseEventsOptions = {
+    /**
+     * Yields comment-only blocks (e.g. keep-alive pings) as events with only
+     * the `comment` field set, and includes comments on regular events.
+     * Defaults to `false`, where comments are skipped entirely.
+     */
+    comments?: boolean;
+};
 
 /**
  * A fetch-flavored reading interface over an {@link HttpResponse}.
@@ -21,6 +34,9 @@ const zstdDecompress = "zstdDecompress" in zlib ? promisify(zlib.zstdDecompress)
  * first read, so `text()`, `json()`, and `arrayBuffer()` can be called any
  * number of times and combined. Bodies are transparently decompressed based
  * on the `content-encoding` response header.
+ *
+ * {@link TestResponse.sseEvents} is the streaming exception: it consumes the
+ * body incrementally and is mutually exclusive with the buffered readers.
  *
  * A `transfer-encoding` header never appears: chunked framing is applied by
  * Node when writing to a real connection, which in-process tests never do.
@@ -46,6 +62,7 @@ export class TestResponse {
     public readonly headers: Headers;
 
     private bufferedBody: Promise<Buffer> | null = null;
+    private streamingBody = false;
 
     private constructor(inner: HttpResponse) {
         this.inner = inner;
@@ -107,7 +124,70 @@ export class TestResponse {
         return copy.buffer;
     }
 
+    /**
+     * Consumes the body as a Server-Sent-Events stream, yielding one
+     * {@link SseEvent} per event block.
+     *
+     * Multi-line `data:` fields are reassembled with `\n`, and `event`,
+     * `id`, and `retry` are surfaced. Comment lines are skipped unless
+     * {@link SseEventsOptions.comments} is enabled. Blocks that set no
+     * field (after comment filtering) yield nothing, so keep-alive pings
+     * are invisible by default.
+     *
+     * Breaking out of the loop cancels the underlying body stream, which a
+     * streaming handler observes the same way as a client disconnect. Drain
+     * the iterator or break out of it; a generator abandoned mid-stream
+     * keeps the body locked and the handler running.
+     *
+     * Mutually exclusive with the buffered readers (`text()` etc.): calling
+     * this method commits the response to streaming, even before iteration
+     * starts. The body is read raw, without content-encoding decompression.
+     */
+    public sseEvents(options?: SseEventsOptions): AsyncGenerator<SseEvent, void, undefined> {
+        if (this.bufferedBody !== null) {
+            throw new Error(
+                "The body has already been buffered; sseEvents() requires the unconsumed stream",
+            );
+        }
+
+        if (this.streamingBody) {
+            throw new Error("The SSE stream is already being consumed");
+        }
+
+        this.streamingBody = true;
+        return this.streamEvents(options?.comments ?? false);
+    }
+
+    private async *streamEvents(
+        includeComments: boolean,
+    ): AsyncGenerator<SseEvent, void, undefined> {
+        const reader = this.inner.body.readable.getReader();
+        const parser = new SseParser(includeComments);
+
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+
+                if (done) {
+                    break;
+                }
+
+                yield* parser.push(value);
+            }
+
+            yield* parser.end();
+        } finally {
+            reader.cancel().catch(() => {
+                // Cancellation failures of a discarded stream are of no interest.
+            });
+        }
+    }
+
     private buffered(): Promise<Buffer> {
+        if (this.streamingBody) {
+            throw new Error("The body is being consumed as an SSE stream");
+        }
+
         this.bufferedBody ??= this.readAndDecode();
         return this.bufferedBody;
     }
@@ -117,6 +197,185 @@ export class TestResponse {
         return decodeBody(raw, this.headers.get("content-encoding"));
     }
 }
+
+type SseBlock = {
+    comments: string[];
+    event?: string;
+    dataLines: string[];
+    id?: string;
+    retry?: number;
+};
+
+const emptyBlock = (): SseBlock => ({ comments: [], dataLines: [] });
+
+/**
+ * Incremental parser for the SSE wire format: bytes in, complete
+ * {@link SseEvent}s out.
+ */
+class SseParser {
+    private readonly includeComments: boolean;
+    private readonly decoder = new TextDecoder();
+    private buffer = "";
+    private block = emptyBlock();
+
+    public constructor(includeComments: boolean) {
+        this.includeComments = includeComments;
+    }
+
+    public push(chunk: Uint8Array): SseEvent[] {
+        this.buffer += this.decoder.decode(chunk, { stream: true });
+
+        const [lines, rest] = extractLines(this.buffer);
+        this.buffer = rest;
+
+        const events: SseEvent[] = [];
+
+        for (const line of lines) {
+            const event = this.processLine(line);
+
+            if (event !== null) {
+                events.push(event);
+            }
+        }
+
+        return events;
+    }
+
+    /**
+     * Flushes the stream end. A trailing CR is a valid terminator for a
+     * blank (dispatching) line; anything else left in the buffer is an
+     * incomplete line or block, which the SSE specification discards.
+     */
+    public end(): SseEvent[] {
+        if (this.buffer !== "\r") {
+            return [];
+        }
+
+        const event = this.processLine("");
+        return event !== null ? [event] : [];
+    }
+
+    private processLine(line: string): SseEvent | null {
+        if (line === "") {
+            const event = dispatchBlock(this.block, this.includeComments);
+            this.block = emptyBlock();
+            return event;
+        }
+
+        processFieldLine(line, this.block);
+        return null;
+    }
+}
+
+/**
+ * Splits off the complete lines in `buffer` (terminated by `\n`, `\r`, or
+ * `\r\n`), returning them and the unterminated rest. A trailing `\r` is held
+ * back, as it may be the first half of a `\r\n` split across chunks.
+ */
+const extractLines = (buffer: string): [string[], string] => {
+    const lines: string[] = [];
+    let start = 0;
+    let index = 0;
+
+    while (index < buffer.length) {
+        const char = buffer[index];
+
+        if (char === "\n") {
+            lines.push(buffer.slice(start, index));
+            start = index + 1;
+            index = start;
+        } else if (char === "\r") {
+            if (index + 1 >= buffer.length) {
+                break;
+            }
+
+            lines.push(buffer.slice(start, index));
+            start = buffer[index + 1] === "\n" ? index + 2 : index + 1;
+            index = start;
+        } else {
+            index++;
+        }
+    }
+
+    return [lines, buffer.slice(start)];
+};
+
+/**
+ * Processes one non-blank line per the SSE parsing algorithm, mutating the
+ * current block.
+ */
+const processFieldLine = (line: string, block: SseBlock): void => {
+    if (line.startsWith(":")) {
+        block.comments.push(stripLeadingSpace(line.slice(1)));
+        return;
+    }
+
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    const value = colon === -1 ? "" : stripLeadingSpace(line.slice(colon + 1));
+
+    switch (field) {
+        case "event": {
+            block.event = value;
+            break;
+        }
+
+        case "data": {
+            block.dataLines.push(value);
+            break;
+        }
+
+        case "id": {
+            if (!value.includes("\0")) {
+                block.id = value;
+            }
+
+            break;
+        }
+
+        case "retry": {
+            if (/^\d+$/.test(value)) {
+                block.retry = Number.parseInt(value, 10);
+            }
+
+            break;
+        }
+
+        default: {
+            // Unknown fields are ignored per the SSE specification.
+            break;
+        }
+    }
+};
+
+const dispatchBlock = (block: SseBlock, includeComments: boolean): SseEvent | null => {
+    const event: SseEvent = {};
+
+    if (includeComments && block.comments.length > 0) {
+        event.comment = block.comments.join("\n");
+    }
+
+    if (block.event !== undefined) {
+        event.event = block.event;
+    }
+
+    if (block.dataLines.length > 0) {
+        event.data = block.dataLines.join("\n");
+    }
+
+    if (block.id !== undefined) {
+        event.id = block.id;
+    }
+
+    if (block.retry !== undefined) {
+        event.retry = block.retry;
+    }
+
+    return Object.keys(event).length > 0 ? event : null;
+};
+
+const stripLeadingSpace = (value: string): string =>
+    value.startsWith(" ") ? value.slice(1) : value;
 
 const decodeBody = async (raw: Buffer, contentEncoding: string | null): Promise<Buffer> => {
     if (contentEncoding === null) {

--- a/packages/testing/src/response.ts
+++ b/packages/testing/src/response.ts
@@ -28,7 +28,7 @@ export type SseEventsOptions = {
  * {@link !Headers} snapshot, so assertions work with any assertion library
  * without importing taxum types. The underlying {@link HttpResponse} remains
  * available via {@link TestResponse.inner} for asserting on extensions, the
- * {@link StatusCode}, or exact multi-value headers.
+ * `StatusCode`, or exact multi-value headers.
  *
  * Unlike fetch, the body readers are repeatable: the body is buffered on
  * first read, so `text()`, `json()`, and `arrayBuffer()` can be called any

--- a/packages/testing/src/response.ts
+++ b/packages/testing/src/response.ts
@@ -1,0 +1,172 @@
+import consumers from "node:stream/consumers";
+import { promisify } from "node:util";
+import zlib from "node:zlib";
+import { HttpResponse, type HttpResponseLike } from "@taxum/core/http";
+
+const gunzip = promisify(zlib.gunzip);
+const inflate = promisify(zlib.inflate);
+const brotliDecompress = promisify(zlib.brotliDecompress);
+const zstdDecompress = "zstdDecompress" in zlib ? promisify(zlib.zstdDecompress) : null;
+
+/**
+ * A fetch-flavored reading interface over an {@link HttpResponse}.
+ *
+ * Exposes the status as a plain number and the headers as a native
+ * {@link !Headers} snapshot, so assertions work with any assertion library
+ * without importing taxum types. The underlying {@link HttpResponse} remains
+ * available via {@link TestResponse.inner} for asserting on extensions, the
+ * {@link StatusCode}, or exact multi-value headers.
+ *
+ * Unlike fetch, the body readers are repeatable: the body is buffered on
+ * first read, so `text()`, `json()`, and `arrayBuffer()` can be called any
+ * number of times and combined. Bodies are transparently decompressed based
+ * on the `content-encoding` response header.
+ *
+ * A `transfer-encoding` header never appears: chunked framing is applied by
+ * Node when writing to a real connection, which in-process tests never do.
+ */
+export class TestResponse {
+    /**
+     * The underlying {@link HttpResponse}.
+     */
+    public readonly inner: HttpResponse;
+
+    /**
+     * Response headers as a native {@link !Headers} snapshot.
+     *
+     * Repeated `set-cookie` headers are accessible via
+     * {@link !Headers.getSetCookie}. Other repeated headers are joined with a
+     * comma on read, matching fetch semantics; use
+     * `inner.headers.getAll(name)` when the individual values matter.
+     *
+     * Headers the WHATWG {@link !Headers} type rejects (e.g. values with
+     * control characters) are omitted from the snapshot; `inner.headers`
+     * always holds the unfiltered response headers.
+     */
+    public readonly headers: Headers;
+
+    private bufferedBody: Promise<Buffer> | null = null;
+
+    private constructor(inner: HttpResponse) {
+        this.inner = inner;
+        this.headers = new Headers();
+
+        for (const [name, value] of inner.headers.entries()) {
+            try {
+                this.headers.append(name, value.value);
+            } catch {
+                // The native Headers type rejects names/values taxum allows
+                // (e.g. control characters); those stay visible via `inner`.
+            }
+        }
+    }
+
+    /**
+     * Creates a new {@link TestResponse} from anything a handler may return.
+     *
+     * Accepts the same values as {@link HttpResponse.from}, so a bare
+     * handler's return value can be wrapped directly:
+     *
+     * ```ts
+     * const res = TestResponse.from(await myHandler(req));
+     * assert.equal(res.status, 200);
+     * ```
+     */
+    public static from(response: HttpResponseLike): TestResponse {
+        return new TestResponse(HttpResponse.from(response));
+    }
+
+    /**
+     * The response status code as a plain number.
+     */
+    public get status(): number {
+        return this.inner.status.code;
+    }
+
+    /**
+     * Reads the body as a UTF-8 string.
+     */
+    public async text(): Promise<string> {
+        return (await this.buffered()).toString("utf-8");
+    }
+
+    /**
+     * Reads the body and parses it as JSON.
+     */
+    public async json<T = unknown>(): Promise<T> {
+        return JSON.parse(await this.text()) as T;
+    }
+
+    /**
+     * Reads the body as an {@link !ArrayBuffer}.
+     */
+    public async arrayBuffer(): Promise<ArrayBuffer> {
+        const buffer = await this.buffered();
+        const copy = new Uint8Array(buffer.byteLength);
+        copy.set(buffer);
+        return copy.buffer;
+    }
+
+    private buffered(): Promise<Buffer> {
+        this.bufferedBody ??= this.readAndDecode();
+        return this.bufferedBody;
+    }
+
+    private async readAndDecode(): Promise<Buffer> {
+        const raw = await consumers.buffer(this.inner.body.readable);
+        return decodeBody(raw, this.headers.get("content-encoding"));
+    }
+}
+
+const decodeBody = async (raw: Buffer, contentEncoding: string | null): Promise<Buffer> => {
+    if (contentEncoding === null) {
+        return raw;
+    }
+
+    const encodings = contentEncoding
+        .split(",")
+        .map((encoding) => encoding.trim().toLowerCase())
+        .filter((encoding) => encoding !== "")
+        .reverse();
+
+    let decoded = raw;
+
+    for (const encoding of encodings) {
+        decoded = await decodeSingle(decoded, encoding);
+    }
+
+    return decoded;
+};
+
+const decodeSingle = async (raw: Buffer, encoding: string): Promise<Buffer> => {
+    switch (encoding) {
+        case "identity": {
+            return raw;
+        }
+
+        case "gzip":
+        case "x-gzip": {
+            return gunzip(raw);
+        }
+
+        case "deflate": {
+            return inflate(raw);
+        }
+
+        case "br": {
+            return brotliDecompress(raw);
+        }
+
+        case "zstd": {
+            if (zstdDecompress === null) {
+                throw new Error("zstd decompression is not supported by this Node.js version");
+            }
+
+            return zstdDecompress(raw);
+        }
+
+        default: {
+            throw new Error(`Unsupported content encoding: ${encoding}`);
+        }
+    }
+};

--- a/packages/testing/src/response.ts
+++ b/packages/testing/src/response.ts
@@ -417,6 +417,7 @@ const decodeSingle = async (raw: Buffer, encoding: string): Promise<Buffer> => {
         }
 
         case "zstd": {
+            /* node:coverage ignore next 3 */
             if (zstdDecompress === null) {
                 throw new Error("zstd decompression is not supported by this Node.js version");
             }

--- a/packages/testing/src/response.ts
+++ b/packages/testing/src/response.ts
@@ -7,6 +7,8 @@ import type { SseEvent } from "@taxum/core/sse";
 const gunzip = promisify(zlib.gunzip);
 const inflate = promisify(zlib.inflate);
 const brotliDecompress = promisify(zlib.brotliDecompress);
+// The availability branch depends on the Node.js version running the tests.
+/* node:coverage ignore next */
 const zstdDecompress = "zstdDecompress" in zlib ? promisify(zlib.zstdDecompress) : null;
 
 /**

--- a/packages/testing/test/client.test.ts
+++ b/packages/testing/test/client.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { SocketAddress } from "node:net";
+import { describe, it } from "node:test";
+import {
+    CONNECT_INFO,
+    ExtensionKey,
+    Extensions,
+    type HttpRequest,
+    HttpResponse,
+} from "@taxum/core/http";
+import { m, Router } from "@taxum/core/routing";
+import { DISCONNECT_SIGNAL, SHUTDOWN_SIGNAL } from "@taxum/core/server";
+import type { HttpService } from "@taxum/core/service";
+import { testClient } from "../src/index.js";
+
+const echoService = (capture: { request?: HttpRequest }): HttpService => ({
+    invoke: (req) => {
+        capture.request = req;
+        return HttpResponse.builder().body("ok");
+    },
+});
+
+describe("client", () => {
+    it("invokes a router route", async () => {
+        const router = new Router().route(
+            "/greet",
+            m.get(() => "hello"),
+        );
+
+        const res = await testClient(router).get("/greet");
+
+        assert.equal(res.status, 200);
+        assert.equal(await res.text(), "hello");
+    });
+
+    it("resolves paths against the base URI and injects a host header", async () => {
+        const capture: { request?: HttpRequest } = {};
+        const client = testClient(echoService(capture), {
+            baseUri: "https://api.example.com",
+        });
+
+        await client.get("/users");
+
+        assert.equal(capture.request?.uri.href, "https://api.example.com/users");
+        assert.equal(capture.request?.headers.get("host")?.value, "api.example.com");
+    });
+
+    it("includes the base URI port in the injected host header", async () => {
+        const capture: { request?: HttpRequest } = {};
+        const client = testClient(echoService(capture), {
+            baseUri: "http://localhost:8080",
+        });
+
+        await client.get("/");
+
+        assert.equal(capture.request?.headers.get("host")?.value, "localhost:8080");
+    });
+
+    it("does not overwrite an explicit host header", async () => {
+        const capture: { request?: HttpRequest } = {};
+
+        await testClient(echoService(capture)).get("/").header("host", "override.example.com");
+
+        assert.equal(capture.request?.headers.get("host")?.value, "override.example.com");
+    });
+
+    it("injects default connect info and inert signals", async () => {
+        const capture: { request?: HttpRequest } = {};
+
+        await testClient(echoService(capture)).get("/");
+
+        const connectInfo = capture.request?.extensions.get(CONNECT_INFO);
+        assert.equal(connectInfo?.address, "127.0.0.1");
+        assert.equal(capture.request?.extensions.get(DISCONNECT_SIGNAL)?.aborted, false);
+        assert.equal(capture.request?.extensions.get(SHUTDOWN_SIGNAL)?.aborted, false);
+    });
+
+    it("uses the configured client IP", async () => {
+        const capture: { request?: HttpRequest } = {};
+        const client = testClient(echoService(capture), { clientIp: "203.0.113.7" });
+
+        await client.get("/");
+
+        assert.equal(capture.request?.extensions.get(CONNECT_INFO)?.address, "203.0.113.7");
+    });
+
+    it("lets a per-request client IP override the configured one", async () => {
+        const capture: { request?: HttpRequest } = {};
+        const client = testClient(echoService(capture), { clientIp: "203.0.113.7" });
+
+        await client.get("/").clientIp("2001:db8::1");
+
+        const connectInfo = capture.request?.extensions.get(CONNECT_INFO);
+        assert.equal(connectInfo?.address, "2001:db8::1");
+        assert.equal(connectInfo?.family, "ipv6");
+    });
+
+    it("accepts a SocketAddress as client IP", async () => {
+        const capture: { request?: HttpRequest } = {};
+        const address = new SocketAddress({ address: "10.0.0.1", family: "ipv4", port: 4711 });
+
+        await testClient(echoService(capture), { clientIp: address }).get("/");
+
+        assert.equal(capture.request?.extensions.get(CONNECT_INFO), address);
+    });
+
+    it("applies client-level extensions to every request without sharing state", async () => {
+        const key = new ExtensionKey<string>("test");
+        const marker = new ExtensionKey<string>("marker");
+        const requests: HttpRequest[] = [];
+        const service: HttpService = {
+            invoke: (req) => {
+                if (requests.length === 0) {
+                    req.extensions.insert(marker, "polluted");
+                }
+
+                requests.push(req);
+                return HttpResponse.builder().body(null);
+            },
+        };
+        const clientExtensions = new Extensions();
+        clientExtensions.insert(key, "value");
+        const client = testClient(service, { extensions: clientExtensions });
+
+        await client.get("/");
+        await client.get("/");
+
+        assert.equal(requests[0].extensions.get(key), "value");
+        assert.equal(requests[1].extensions.get(key), "value");
+        assert.equal(requests[1].extensions.get(marker), undefined);
+    });
+
+    it("lets per-request extensions override client-level extensions", async () => {
+        const key = new ExtensionKey<string>("test");
+        const capture: { request?: HttpRequest } = {};
+        const clientExtensions = new Extensions();
+        clientExtensions.insert(key, "client");
+        const client = testClient(echoService(capture), { extensions: clientExtensions });
+
+        await client.get("/").extension(key, "request");
+
+        assert.equal(capture.request?.extensions.get(key), "request");
+    });
+
+    it("passes a user-supplied disconnect signal through", async () => {
+        const capture: { request?: HttpRequest } = {};
+        const controller = new AbortController();
+
+        await testClient(echoService(capture)).get("/").disconnectSignal(controller.signal);
+
+        assert.equal(capture.request?.extensions.get(DISCONNECT_SIGNAL), controller.signal);
+        controller.abort();
+        assert.equal(capture.request?.extensions.get(DISCONNECT_SIGNAL)?.aborted, true);
+    });
+
+    it("sends each verb with the matching method", async () => {
+        const capture: { request?: HttpRequest } = {};
+        const client = testClient(echoService(capture));
+        const verbs = [
+            ["get", "GET"],
+            ["post", "POST"],
+            ["put", "PUT"],
+            ["patch", "PATCH"],
+            ["delete", "DELETE"],
+            ["head", "HEAD"],
+            ["options", "OPTIONS"],
+        ] as const;
+
+        for (const [verb, method] of verbs) {
+            await client[verb]("/");
+            assert.equal(capture.request?.method.value, method);
+        }
+    });
+
+    it("propagates service rejections untouched", async () => {
+        const failure = new Error("boom");
+        const service: HttpService = {
+            invoke: () => {
+                throw failure;
+            },
+        };
+
+        await assert.rejects(testClient(service).get("/"), failure);
+    });
+});

--- a/packages/testing/test/jar.test.ts
+++ b/packages/testing/test/jar.test.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { type HttpRequest, HttpResponse } from "@taxum/core/http";
+import { m, Router } from "@taxum/core/routing";
+import type { HttpService } from "@taxum/core/service";
+import { TestCookieJar, testClient } from "../src/index.js";
+
+const uri = (path: string, protocol = "http"): URL => new URL(`${protocol}://localhost${path}`);
+
+describe("jar", () => {
+    describe("TestCookieJar", () => {
+        it("stores and retrieves seeded cookies", () => {
+            const jar = new TestCookieJar();
+            jar.set("session", "abc");
+
+            assert.equal(jar.get("session")?.value, "abc");
+            assert.equal(jar.get("session")?.path, "/");
+            assert.equal(jar.get("missing"), null);
+        });
+
+        it("seeds cookies with attributes via the object form", () => {
+            const jar = new TestCookieJar();
+            jar.set({ name: "scoped", value: "1", path: "/admin", secure: true });
+
+            assert.equal(jar.get("scoped")?.path, "/admin");
+            assert.equal(jar.get("scoped")?.secure, true);
+        });
+
+        it("deletes cookies by name across paths and clears entirely", () => {
+            const jar = new TestCookieJar();
+            jar.set({ name: "a", value: "1", path: "/x" });
+            jar.set({ name: "a", value: "2", path: "/y" });
+            jar.set("b", "3");
+
+            jar.delete("a");
+            assert.equal(jar.get("a"), null);
+            assert.equal(jar.get("b")?.value, "3");
+
+            jar.clear();
+            assert.deepEqual([...jar], []);
+        });
+
+        it("keys cookies by name and path", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("pref=old; Path=/a", uri("/"));
+            jar.ingest("pref=new; Path=/a", uri("/"));
+            jar.ingest("pref=other; Path=/b", uri("/"));
+
+            assert.equal([...jar].length, 2);
+            assert.equal(jar.cookiesFor(uri("/a"))[0]?.value, "new");
+        });
+
+        it("parses attributes from set-cookie headers", () => {
+            const jar = new TestCookieJar();
+            jar.ingest(
+                "sid=abc; Path=/app; Max-Age=3600; Secure; HttpOnly; SameSite=Lax",
+                uri("/"),
+            );
+
+            const cookie = jar.get("sid");
+            assert.equal(cookie?.value, "abc");
+            assert.equal(cookie?.path, "/app");
+            assert.equal(cookie?.maxAge, 3600);
+            assert.equal(cookie?.secure, true);
+            assert.equal(cookie?.httpOnly, true);
+            assert.equal(cookie?.sameSite, "Lax");
+        });
+
+        it("keeps values verbatim without percent-decoding", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("enc=a%20b%3D; Path=/", uri("/"));
+
+            assert.equal(jar.get("enc")?.value, "a%20b%3D");
+        });
+
+        it("derives the default path from the request URI", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("a=1", uri("/admin/settings"));
+            jar.ingest("b=2", uri("/top"));
+
+            assert.equal(jar.get("a")?.path, "/admin");
+            assert.equal(jar.get("b")?.path, "/");
+        });
+
+        it("treats empty or relative Path attributes as absent", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("a=1; Path=", uri("/deep/page"));
+            jar.ingest("b=2; Path=foo", uri("/deep/page"));
+
+            assert.equal(jar.get("a")?.path, "/deep");
+            assert.equal(jar.get("b")?.path, "/deep");
+        });
+
+        it("defaults secure and httpOnly to false", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("plain=1", uri("/"));
+            jar.set("seeded", "2");
+
+            assert.equal(jar.get("plain")?.secure, false);
+            assert.equal(jar.get("plain")?.httpOnly, false);
+            assert.equal(jar.get("seeded")?.secure, false);
+        });
+
+        it("treats a malformed Expires as a session cookie", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("odd=1; Expires=garbage", uri("/"));
+
+            assert.equal(jar.get("odd")?.value, "1");
+            assert.equal(jar.cookiesFor(uri("/")).length, 1);
+        });
+
+        it("removes cookies via a negative Max-Age", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("sid=abc; Path=/", uri("/"));
+            jar.ingest("sid=; Path=/; Max-Age=-1", uri("/"));
+
+            assert.equal(jar.get("sid"), null);
+        });
+
+        it("returns the longest-path cookie from get() when names collide", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("s=outer; Path=/", uri("/"));
+            jar.ingest("s=inner; Path=/a/b", uri("/"));
+
+            assert.equal(jar.get("s")?.value, "inner");
+        });
+
+        it("removes cookies via Max-Age=0", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("sid=abc; Path=/", uri("/"));
+            jar.ingest("sid=; Path=/; Max-Age=0", uri("/"));
+
+            assert.equal(jar.get("sid"), null);
+        });
+
+        it("drops cookies whose expiry has passed", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("old=1; Expires=Wed, 21 Oct 2015 07:28:00 GMT", uri("/"));
+            jar.ingest("fresh=1; Max-Age=3600", uri("/"));
+
+            assert.equal(jar.get("old"), null);
+            assert.equal(jar.get("fresh")?.value, "1");
+        });
+
+        it("prefers max-age over expires", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("mixed=1; Max-Age=3600; Expires=Wed, 21 Oct 2015 07:28:00 GMT", uri("/"));
+
+            assert.equal(jar.get("mixed")?.value, "1");
+        });
+
+        it("matches cookie paths per RFC 6265", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("scoped=1; Path=/admin", uri("/"));
+
+            assert.equal(jar.cookiesFor(uri("/admin")).length, 1);
+            assert.equal(jar.cookiesFor(uri("/admin/users")).length, 1);
+            assert.equal(jar.cookiesFor(uri("/administrator")).length, 0);
+            assert.equal(jar.cookiesFor(uri("/public")).length, 0);
+        });
+
+        it("withholds secure cookies from http URIs", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("sid=abc; Path=/; Secure", uri("/"));
+
+            assert.equal(jar.cookiesFor(uri("/", "http")).length, 0);
+            assert.equal(jar.cookiesFor(uri("/", "https")).length, 1);
+        });
+
+        it("sends domain and httpOnly cookies regardless", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("a=1; Domain=other.example; HttpOnly", uri("/"));
+
+            assert.equal(jar.cookiesFor(uri("/")).length, 1);
+        });
+
+        it("orders matches by longest path first", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("outer=1; Path=/", uri("/"));
+            jar.ingest("inner=2; Path=/admin", uri("/"));
+
+            assert.deepEqual(
+                jar.cookiesFor(uri("/admin/x")).map((cookie) => cookie.name),
+                ["inner", "outer"],
+            );
+        });
+    });
+
+    describe("client integration", () => {
+        it("captures cookies and sends them on subsequent requests", async () => {
+            let seenCookie: string | null = null;
+            const router = new Router()
+                .route(
+                    "/login",
+                    m.post(() =>
+                        HttpResponse.builder()
+                            .header("set-cookie", "session=abc; Path=/")
+                            .body("ok"),
+                    ),
+                )
+                .route(
+                    "/me",
+                    m.get((req: HttpRequest) => {
+                        seenCookie = req.headers.get("cookie")?.value ?? null;
+                        return "me";
+                    }),
+                );
+            const client = testClient(router, { saveCookies: true });
+
+            await client.post("/login").body(null);
+            await client.get("/me");
+
+            assert.equal(seenCookie, "session=abc");
+            assert.equal(client.cookies.get("session")?.value, "abc");
+        });
+
+        it("does not capture cookies when saveCookies is off", async () => {
+            const service: HttpService = {
+                invoke: () =>
+                    HttpResponse.builder().header("set-cookie", "sid=1; Path=/").body(null),
+            };
+            const client = testClient(service);
+
+            await client.get("/");
+
+            assert.equal(client.cookies.get("sid"), null);
+        });
+
+        it("sends seeded cookies even when saveCookies is off", async () => {
+            const capture: { request?: HttpRequest } = {};
+            const service: HttpService = {
+                invoke: (req) => {
+                    capture.request = req;
+                    return HttpResponse.builder().body(null);
+                },
+            };
+            const client = testClient(service);
+            client.cookies.set("session", "seeded");
+
+            await client.get("/");
+
+            assert.equal(capture.request?.headers.get("cookie")?.value, "session=seeded");
+        });
+
+        it("merges jar cookies with per-request cookies", async () => {
+            const capture: { request?: HttpRequest } = {};
+            const service: HttpService = {
+                invoke: (req) => {
+                    capture.request = req;
+                    return HttpResponse.builder().body(null);
+                },
+            };
+            const client = testClient(service);
+            client.cookies.set("jarred", "1");
+
+            await client.get("/").cookie("adhoc", "2");
+
+            assert.equal(capture.request?.headers.get("cookie")?.value, "jarred=1; adhoc=2");
+        });
+
+        it("captures multiple set-cookie headers from one response", async () => {
+            const service: HttpService = {
+                invoke: () =>
+                    HttpResponse.builder()
+                        .header("set-cookie", "a=1; Path=/")
+                        .header("set-cookie", "b=2; Path=/")
+                        .body(null),
+            };
+            const client = testClient(service, { saveCookies: true });
+
+            await client.get("/");
+
+            assert.equal(client.cookies.get("a")?.value, "1");
+            assert.equal(client.cookies.get("b")?.value, "2");
+        });
+
+        it("respects path scoping end to end", async () => {
+            const cookies: (string | null)[] = [];
+            const service: HttpService = {
+                invoke: (req) => {
+                    cookies.push(req.headers.get("cookie")?.value ?? null);
+
+                    if (req.uri.pathname === "/admin/login") {
+                        return HttpResponse.builder()
+                            .header("set-cookie", "admin=1; Path=/admin")
+                            .body(null);
+                    }
+
+                    return HttpResponse.builder().body(null);
+                },
+            };
+            const client = testClient(service, { saveCookies: true });
+
+            await client.get("/admin/login");
+            await client.get("/admin/panel");
+            await client.get("/public");
+
+            assert.deepEqual(cookies, [null, "admin=1", null]);
+        });
+    });
+});

--- a/packages/testing/test/jar.test.ts
+++ b/packages/testing/test/jar.test.ts
@@ -137,12 +137,25 @@ describe("jar", () => {
             assert.equal(jar.get("sid"), null);
         });
 
-        it("returns the longest-path cookie from get() when names collide", () => {
+        it("throws from get() when names collide and no path is given", () => {
             const jar = new TestCookieJar();
             jar.ingest("s=outer; Path=/", uri("/"));
             jar.ingest("s=inner; Path=/a/b", uri("/"));
 
-            assert.equal(jar.get("s")?.value, "inner");
+            assert.throws(
+                () => jar.get("s"),
+                /Multiple cookies named "s" \(paths "\/", "\/a\/b"\)/,
+            );
+        });
+
+        it("returns the exact-path cookie from get() when a path is given", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("s=outer; Path=/", uri("/"));
+            jar.ingest("s=inner; Path=/a/b", uri("/"));
+
+            assert.equal(jar.get("s", "/")?.value, "outer");
+            assert.equal(jar.get("s", "/a/b")?.value, "inner");
+            assert.equal(jar.get("s", "/other"), null);
         });
 
         it("removes cookies via Max-Age=0", () => {

--- a/packages/testing/test/jar.test.ts
+++ b/packages/testing/test/jar.test.ts
@@ -109,6 +109,26 @@ describe("jar", () => {
             assert.equal(jar.cookiesFor(uri("/")).length, 1);
         });
 
+        it("ignores malformed set-cookie headers", () => {
+            const jar = new TestCookieJar();
+            jar.ingest("", uri("/"));
+            jar.ingest("=value", uri("/"));
+            jar.ingest("; Secure", uri("/"));
+
+            assert.deepEqual([...jar], []);
+        });
+
+        it("purges cookies that expire while stored", async () => {
+            const jar = new TestCookieJar();
+            jar.set({ name: "shortlived", value: "1", maxAge: 0.001 });
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 10);
+            });
+
+            assert.equal(jar.get("shortlived"), null);
+        });
+
         it("removes cookies via a negative Max-Age", () => {
             const jar = new TestCookieJar();
             jar.ingest("sid=abc; Path=/", uri("/"));

--- a/packages/testing/test/request.test.ts
+++ b/packages/testing/test/request.test.ts
@@ -225,6 +225,19 @@ describe("request", () => {
             assert.throws(() => request.header("x-late", "1"), /already been sent/);
         });
 
+        it("supports finally on the request itself", async () => {
+            let cleanedUp = false;
+
+            const res = await testClient(echoService({}))
+                .get("/")
+                .finally(() => {
+                    cleanedUp = true;
+                });
+
+            assert.equal(res.status, 200);
+            assert.equal(cleanedUp, true);
+        });
+
         it("supports catch and finally", async () => {
             const service: HttpService = {
                 invoke: () => {
@@ -266,6 +279,24 @@ describe("request", () => {
             const res = await testClient(router).head("/missing");
 
             assert.equal(res.status, 404);
+            assert.equal(await res.text(), "");
+        });
+
+        it("swallows body cancellation failures when discarding", async () => {
+            const stream = new ReadableStream<Uint8Array>({
+                start: (controller) => {
+                    controller.enqueue(new TextEncoder().encode("hidden"));
+                },
+                cancel: () => {
+                    throw new Error("cancel failed");
+                },
+            });
+            const service: HttpService = {
+                invoke: () => HttpResponse.builder().body(stream),
+            };
+
+            const res = await testClient(service).head("/");
+
             assert.equal(await res.text(), "");
         });
 

--- a/packages/testing/test/request.test.ts
+++ b/packages/testing/test/request.test.ts
@@ -1,0 +1,321 @@
+import assert from "node:assert/strict";
+import consumers from "node:stream/consumers";
+import { describe, it } from "node:test";
+import { HeaderMap, type HttpRequest, HttpResponse, StatusCode } from "@taxum/core/http";
+import { m, Router } from "@taxum/core/routing";
+import type { HttpService } from "@taxum/core/service";
+import { testClient } from "../src/index.js";
+
+const echoService = (capture: { request?: HttpRequest }): HttpService => ({
+    invoke: (req) => {
+        capture.request = req;
+        return HttpResponse.builder().body("ok");
+    },
+});
+
+describe("request", () => {
+    describe("query", () => {
+        it("encodes a flat record with arrays as repeated keys", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture))
+                .get("/search")
+                .query({ q: "taxum", page: 2, exact: true, tag: ["a", "b"] });
+
+            assert.equal(capture.request?.uri.search, "?q=taxum&page=2&exact=true&tag=a&tag=b");
+        });
+
+        it("merges with a query string already present in the path", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture)).get("/search?a=1").query({ b: "2" });
+
+            assert.equal(capture.request?.uri.search, "?a=1&b=2");
+        });
+
+        it("merges multiple query() calls", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture))
+                .get("/search")
+                .query({ a: "1" })
+                .query({ b: "2" });
+
+            assert.equal(capture.request?.uri.search, "?a=1&b=2");
+        });
+
+        it("accepts a raw query string", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture)).get("/items").query("filter[status]=open");
+
+            assert.equal(capture.request?.uri.searchParams.get("filter[status]"), "open");
+        });
+
+        it("accepts URLSearchParams", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture))
+                .get("/items")
+                .query(new URLSearchParams({ a: "1" }));
+
+            assert.equal(capture.request?.uri.search, "?a=1");
+        });
+    });
+
+    describe("paths", () => {
+        it("rejects paths not starting with a single slash", () => {
+            const client = testClient(echoService({}));
+
+            assert.throws(() => client.get("users"), /must start with a single "\/"/);
+            assert.throws(() => client.get("http://evil.example/x"), /must start/);
+            assert.throws(() => client.get("//evil.example/x"), /must start/);
+        });
+
+        it("strips URI fragments", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture)).get("/page#section");
+
+            assert.equal(capture.request?.uri.hash, "");
+            assert.equal(capture.request?.uri.pathname, "/page");
+        });
+    });
+
+    describe("bodies", () => {
+        it("sends a JSON body with content-type and content-length", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture)).post("/users").json({ name: "Ben" });
+
+            assert.ok(capture.request);
+            assert.equal(capture.request.headers.get("content-type")?.value, "application/json");
+            assert.equal(
+                capture.request.headers.get("content-length")?.value,
+                JSON.stringify({ name: "Ben" }).length.toString(),
+            );
+            assert.deepEqual(JSON.parse(await consumers.text(capture.request.body.readable)), {
+                name: "Ben",
+            });
+        });
+
+        it("sends a form body URL-encoded", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture)).post("/login").form({ user: "ben", id: 5 });
+
+            assert.ok(capture.request);
+            assert.equal(
+                capture.request.headers.get("content-type")?.value,
+                "application/x-www-form-urlencoded",
+            );
+            assert.equal(await consumers.text(capture.request.body.readable), "user=ben&id=5");
+        });
+
+        it("lets an explicit content-type win over the implied one", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture))
+                .post("/users")
+                .header("content-type", "application/vnd.custom+json")
+                .json({});
+
+            assert.equal(
+                capture.request?.headers.get("content-type")?.value,
+                "application/vnd.custom+json",
+            );
+        });
+
+        it("sets content-length in bytes, not code units, for multibyte bodies", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture)).post("/").body("héllo");
+
+            assert.equal(capture.request?.headers.get("content-length")?.value, "6");
+        });
+
+        it("implies no content-type for raw bodies", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture)).post("/upload").body("raw");
+
+            assert.equal(capture.request?.headers.get("content-type"), null);
+        });
+
+        it("rejects a second body at runtime when the unsealed builder is aliased", () => {
+            const request = testClient(echoService({})).post("/");
+            request.json({});
+
+            assert.throws(() => request.body("again"), /body has already been set/);
+        });
+
+        it("rejects values that are not JSON-serializable", () => {
+            assert.throws(
+                () => testClient(echoService({})).post("/").json(undefined),
+                /not JSON-serializable/,
+            );
+        });
+    });
+
+    describe("headers and cookies", () => {
+        it("appends bulk headers from entries and HeaderMap", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture))
+                .get("/")
+                .headers([["x-a", "1"]])
+                .headers(HeaderMap.from([["x-b", "2"]]));
+
+            assert.equal(capture.request?.headers.get("x-a")?.value, "1");
+            assert.equal(capture.request?.headers.get("x-b")?.value, "2");
+        });
+
+        it("joins cookies into a single cookie header", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture))
+                .get("/")
+                .cookie("session", "abc")
+                .cookie("theme", "dark");
+
+            assert.deepEqual(
+                capture.request?.headers.getAll("cookie").map((value) => value.value),
+                ["session=abc; theme=dark"],
+            );
+        });
+
+        it("merges cookies with an explicit cookie header", async () => {
+            const capture: { request?: HttpRequest } = {};
+
+            await testClient(echoService(capture))
+                .get("/")
+                .header("cookie", "existing=1")
+                .cookie("session", "abc");
+
+            assert.deepEqual(
+                capture.request?.headers.getAll("cookie").map((value) => value.value),
+                ["existing=1; session=abc"],
+            );
+        });
+    });
+
+    describe("send semantics", () => {
+        it("sends exactly once for repeated awaits", async () => {
+            let invocations = 0;
+            const service: HttpService = {
+                invoke: () => {
+                    invocations++;
+                    return HttpResponse.builder().body("ok");
+                },
+            };
+            const request = testClient(service).get("/");
+
+            const [first, second] = await Promise.all([request, request]);
+            const third = await request;
+
+            assert.equal(invocations, 1);
+            assert.equal(first, second);
+            assert.equal(second, third);
+        });
+
+        it("rejects mutation after send", async () => {
+            const request = testClient(echoService({})).get("/");
+            await request;
+
+            assert.throws(() => request.header("x-late", "1"), /already been sent/);
+        });
+
+        it("supports catch and finally", async () => {
+            const service: HttpService = {
+                invoke: () => {
+                    throw new Error("boom");
+                },
+            };
+            let cleanedUp = false;
+
+            const caught = await testClient(service)
+                .get("/")
+                .catch((error) => error as Error)
+                .finally(() => {
+                    cleanedUp = true;
+                });
+
+            assert.equal((caught as Error).message, "boom");
+            assert.equal(cleanedUp, true);
+        });
+    });
+
+    describe("response normalization", () => {
+        it("discards HEAD bodies from non-router services", async () => {
+            const service: HttpService = {
+                invoke: () => HttpResponse.builder().body("hidden"),
+            };
+
+            const res = await testClient(service).head("/");
+
+            assert.equal(await res.text(), "");
+            assert.equal(res.headers.get("content-length"), null);
+        });
+
+        it("discards HEAD bodies on router fallback paths", async () => {
+            const router = new Router().route(
+                "/exists",
+                m.get(() => "hello"),
+            );
+
+            const res = await testClient(router).head("/missing");
+
+            assert.equal(res.status, 404);
+            assert.equal(await res.text(), "");
+        });
+
+        it("strips body and framing headers from 204 responses", async () => {
+            const service: HttpService = {
+                invoke: () =>
+                    HttpResponse.builder()
+                        .status(StatusCode.NO_CONTENT)
+                        .header("content-length", "5")
+                        .body("stale"),
+            };
+
+            const res = await testClient(service).get("/");
+
+            assert.equal(res.status, 204);
+            assert.equal(res.headers.get("content-length"), null);
+            assert.equal(await res.text(), "");
+        });
+
+        it("does not invent content-length where production sends chunked", async () => {
+            const service: HttpService = {
+                invoke: () => HttpResponse.builder().body("hello"),
+            };
+
+            const res = await testClient(service).get("/");
+
+            assert.equal(res.headers.get("content-length"), null);
+        });
+
+        it("keeps the content-length set by the route layer on matched routes", async () => {
+            const router = new Router().route(
+                "/greet",
+                m.get(() => "hello"),
+            );
+
+            const res = await testClient(router).get("/greet");
+
+            assert.equal(res.headers.get("content-length"), "5");
+        });
+
+        it("does not invent content-length on router fallback responses", async () => {
+            const router = new Router().route(
+                "/exists",
+                m.get(() => "hello"),
+            );
+
+            const res = await testClient(router).get("/missing");
+
+            assert.equal(res.status, 404);
+            assert.equal(res.headers.get("content-length"), null);
+        });
+    });
+});

--- a/packages/testing/test/response.test.ts
+++ b/packages/testing/test/response.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { brotliCompressSync, deflateSync, gzipSync } from "node:zlib";
+import zlib, { brotliCompressSync, deflateSync, gzipSync } from "node:zlib";
 import { HeaderMap, HeaderValue, HttpResponse, StatusCode } from "@taxum/core/http";
 import { TestResponse } from "../src/index.js";
 
@@ -105,6 +105,18 @@ describe("response", () => {
         );
 
         assert.equal(await res.text(), "brotli payload");
+    });
+
+    it("decompresses zstd bodies", {
+        skip: !("zstdCompressSync" in zlib) && "zstd is unavailable in this Node.js version",
+    }, async () => {
+        const res = TestResponse.from(
+            HttpResponse.builder()
+                .header("content-encoding", "zstd")
+                .body(zlib.zstdCompressSync("zstd payload")),
+        );
+
+        assert.equal(await res.text(), "zstd payload");
     });
 
     it("decodes chained encodings in reverse application order", async () => {

--- a/packages/testing/test/response.test.ts
+++ b/packages/testing/test/response.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { brotliCompressSync, deflateSync, gzipSync } from "node:zlib";
+import { HeaderMap, HeaderValue, HttpResponse, StatusCode } from "@taxum/core/http";
+import { TestResponse } from "../src/index.js";
+
+describe("response", () => {
+    it("wraps anything a handler may return", async () => {
+        const res = TestResponse.from("hello");
+
+        assert.equal(res.status, 200);
+        assert.equal(await res.text(), "hello");
+    });
+
+    it("exposes the status as a number and the StatusCode via inner", () => {
+        const res = TestResponse.from(HttpResponse.builder().status(StatusCode.CREATED).body(null));
+
+        assert.equal(res.status, 201);
+        assert.equal(res.inner.status, StatusCode.CREATED);
+    });
+
+    it("exposes headers as a native Headers snapshot", () => {
+        const res = TestResponse.from(
+            HttpResponse.builder().header("content-type", "text/plain").body(null),
+        );
+
+        assert.equal(res.headers.get("content-type"), "text/plain");
+        assert.equal(res.headers.get("missing"), null);
+    });
+
+    it("exposes repeated set-cookie headers via getSetCookie", () => {
+        const res = TestResponse.from(
+            HttpResponse.builder()
+                .header("set-cookie", "a=1; Path=/")
+                .header("set-cookie", "b=2; Secure")
+                .body(null),
+        );
+
+        assert.deepEqual(res.headers.getSetCookie(), ["a=1; Path=/", "b=2; Secure"]);
+    });
+
+    it("omits headers the native Headers type rejects, keeping them on inner", () => {
+        const headers = new HeaderMap();
+        headers.insert("x-evil", "line1\nline2");
+        headers.insert("x-fine", "ok");
+
+        const res = TestResponse.from(HttpResponse.builder().headers(headers).body(null));
+
+        assert.equal(res.headers.get("x-evil"), null);
+        assert.equal(res.headers.get("x-fine"), "ok");
+        assert.equal(res.inner.headers.get("x-evil")?.value, "line1\nline2");
+    });
+
+    it("exposes sensitive header values, not their masked form", () => {
+        const headers = new HeaderMap();
+        headers.insert("authorization", new HeaderValue("Bearer secret", true));
+
+        const res = TestResponse.from(HttpResponse.builder().headers(headers).body(null));
+
+        assert.equal(res.headers.get("authorization"), "Bearer secret");
+    });
+
+    it("reads text and json repeatedly", async () => {
+        const res = TestResponse.from(HttpResponse.builder().body(JSON.stringify({ id: "5" })));
+
+        assert.deepEqual(await res.json(), { id: "5" });
+        assert.deepEqual(await res.json<{ id: string }>(), { id: "5" });
+        assert.equal(await res.text(), '{"id":"5"}');
+    });
+
+    it("reads the body as an ArrayBuffer", async () => {
+        const res = TestResponse.from("abc");
+
+        const buffer = await res.arrayBuffer();
+
+        assert.equal(new TextDecoder().decode(buffer), "abc");
+        assert.equal(await res.text(), "abc");
+    });
+
+    it("decompresses gzip bodies transparently", async () => {
+        const res = TestResponse.from(
+            HttpResponse.builder()
+                .header("content-encoding", "gzip")
+                .body(gzipSync("compressed payload")),
+        );
+
+        assert.equal(await res.text(), "compressed payload");
+    });
+
+    it("decompresses deflate bodies", async () => {
+        const res = TestResponse.from(
+            HttpResponse.builder()
+                .header("content-encoding", "deflate")
+                .body(deflateSync("deflated payload")),
+        );
+
+        assert.equal(await res.text(), "deflated payload");
+    });
+
+    it("decompresses brotli bodies", async () => {
+        const res = TestResponse.from(
+            HttpResponse.builder()
+                .header("content-encoding", "br")
+                .body(brotliCompressSync("brotli payload")),
+        );
+
+        assert.equal(await res.text(), "brotli payload");
+    });
+
+    it("decodes chained encodings in reverse application order", async () => {
+        const res = TestResponse.from(
+            HttpResponse.builder()
+                .header("content-encoding", "deflate, gzip")
+                .body(gzipSync(deflateSync("chained payload"))),
+        );
+
+        assert.equal(await res.text(), "chained payload");
+    });
+
+    it("passes identity encoding through", async () => {
+        const res = TestResponse.from(
+            HttpResponse.builder().header("content-encoding", "identity").body("plain"),
+        );
+
+        assert.equal(await res.text(), "plain");
+    });
+
+    it("throws on unsupported content encodings", async () => {
+        const res = TestResponse.from(
+            HttpResponse.builder().header("content-encoding", "bogus").body("x"),
+        );
+
+        await assert.rejects(res.text(), /Unsupported content encoding: bogus/);
+    });
+});

--- a/packages/testing/test/sse.test.ts
+++ b/packages/testing/test/sse.test.ts
@@ -108,6 +108,12 @@ describe("sse", () => {
         assert.deepEqual(events, [{ data: "a" }, { data: "b" }]);
     });
 
+    it("ignores a trailing CR terminating an empty block", async () => {
+        const events = await collect(sseResponse("data: a\n\n\r"));
+
+        assert.deepEqual(events, [{ data: "a" }]);
+    });
+
     it("parses events split across arbitrary chunk boundaries", async () => {
         const wire = "event: update\r\ndata: first\n\ndata: second\r\r";
 

--- a/packages/testing/test/sse.test.ts
+++ b/packages/testing/test/sse.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { HttpResponse } from "@taxum/core/http";
+import { m, Router } from "@taxum/core/routing";
+import { Sse, type SseEvent } from "@taxum/core/sse";
+import { TestResponse, testClient } from "../src/index.js";
+
+const encoder = new TextEncoder();
+
+const sseResponse = (wire: string, chunkSize = Number.POSITIVE_INFINITY): TestResponse => {
+    const bytes = encoder.encode(wire);
+    const chunks: Uint8Array[] = [];
+
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+        chunks.push(bytes.slice(offset, offset + chunkSize));
+    }
+
+    return TestResponse.from(
+        HttpResponse.builder()
+            .header("content-type", "text/event-stream")
+            .body(ReadableStream.from(chunks)),
+    );
+};
+
+const collect = async (
+    res: TestResponse,
+    options?: { comments?: boolean },
+): Promise<SseEvent[]> => {
+    const events: SseEvent[] = [];
+
+    for await (const event of res.sseEvents(options)) {
+        events.push(event);
+    }
+
+    return events;
+};
+
+describe("sse", () => {
+    it("parses events in core's wire format", async () => {
+        const wire = "event: update\ndata: first\nid: 1\nretry: 5000\n\ndata: second\n\nid: 3\n\n";
+
+        assert.deepEqual(await collect(sseResponse(wire)), [
+            { event: "update", data: "first", id: "1", retry: 5000 },
+            { data: "second" },
+            { id: "3" },
+        ]);
+    });
+
+    it("reassembles multi-line data", async () => {
+        const events = await collect(sseResponse("data: line1\ndata: line2\ndata: line3\n\n"));
+
+        assert.deepEqual(events, [{ data: "line1\nline2\nline3" }]);
+    });
+
+    it("strips exactly one leading space from field values", async () => {
+        const events = await collect(sseResponse("data:no-space\n\ndata:  padded\n\n"));
+
+        assert.deepEqual(events, [{ data: "no-space" }, { data: " padded" }]);
+    });
+
+    it("skips comments by default, including keep-alive blocks", async () => {
+        const wire = ": keep-alive\n\ndata: real\n: inline comment\n\n: another ping\n\n";
+
+        const events = await collect(sseResponse(wire));
+
+        assert.deepEqual(events, [{ data: "real" }]);
+    });
+
+    it("yields comments when opted in", async () => {
+        const wire = ": keep-alive\n\ndata: real\n: inline\n\n";
+
+        const events = await collect(sseResponse(wire), { comments: true });
+
+        assert.deepEqual(events, [{ comment: "keep-alive" }, { comment: "inline", data: "real" }]);
+    });
+
+    it("ignores invalid retry and id fields", async () => {
+        const wire = "retry: abc\ndata: x\n\nid: with\0nul\ndata: y\n\n";
+
+        const events = await collect(sseResponse(wire));
+
+        assert.deepEqual(events, [{ data: "x" }, { data: "y" }]);
+    });
+
+    it("ignores unknown fields and fieldless lines", async () => {
+        const wire = "custom: ignored\nnocolon\ndata: kept\n\n";
+
+        const events = await collect(sseResponse(wire));
+
+        assert.deepEqual(events, [{ data: "kept" }]);
+    });
+
+    it("treats a lone data field with empty value as empty data", async () => {
+        const events = await collect(sseResponse("data:\n\n"));
+
+        assert.deepEqual(events, [{ data: "" }]);
+    });
+
+    it("discards an incomplete trailing block", async () => {
+        const events = await collect(sseResponse("data: complete\n\ndata: incomplete\n"));
+
+        assert.deepEqual(events, [{ data: "complete" }]);
+    });
+
+    it("handles CRLF and CR line endings", async () => {
+        const events = await collect(sseResponse("data: a\r\n\r\ndata: b\r\r"));
+
+        assert.deepEqual(events, [{ data: "a" }, { data: "b" }]);
+    });
+
+    it("parses events split across arbitrary chunk boundaries", async () => {
+        const wire = "event: update\r\ndata: first\n\ndata: second\r\r";
+
+        for (const chunkSize of [1, 2, 3, 5]) {
+            const events = await collect(sseResponse(wire, chunkSize));
+
+            assert.deepEqual(events, [{ event: "update", data: "first" }, { data: "second" }]);
+        }
+    });
+
+    it("cancels the body stream when the consumer breaks", async () => {
+        let cancelled = false;
+        const stream = new ReadableStream<Uint8Array>({
+            start: (controller) => {
+                controller.enqueue(encoder.encode("data: one\n\n"));
+            },
+            cancel: () => {
+                cancelled = true;
+            },
+        });
+        const res = TestResponse.from(HttpResponse.builder().body(stream));
+
+        for await (const event of res.sseEvents()) {
+            assert.deepEqual(event, { data: "one" });
+            break;
+        }
+
+        assert.equal(cancelled, true);
+    });
+
+    it("is mutually exclusive with the buffered readers", async () => {
+        const buffered = sseResponse("data: x\n\n");
+        await buffered.text();
+        assert.throws(() => buffered.sseEvents(), /already been buffered/);
+
+        const streamed = sseResponse("data: x\n\n");
+        await collect(streamed);
+        await assert.rejects(streamed.text(), /consumed as an SSE stream/);
+        assert.throws(() => streamed.sseEvents(), /already being consumed/);
+    });
+
+    it("rejects the iteration with the original stream error", async () => {
+        const failure = new Error("stream broke");
+        let pulls = 0;
+        const stream = new ReadableStream<Uint8Array>({
+            pull: (controller) => {
+                pulls++;
+
+                if (pulls === 1) {
+                    controller.enqueue(encoder.encode("data: one\n\n"));
+                } else {
+                    controller.error(failure);
+                }
+            },
+        });
+        const res = TestResponse.from(HttpResponse.builder().body(stream));
+        const events: SseEvent[] = [];
+
+        await assert.rejects(async () => {
+            for await (const event of res.sseEvents()) {
+                events.push(event);
+            }
+        }, failure);
+
+        assert.deepEqual(events, [{ data: "one" }]);
+    });
+
+    it("commits the response to streaming as soon as sseEvents() is called", async () => {
+        const res = sseResponse("data: x\n\n");
+        void res.sseEvents();
+
+        await assert.rejects(res.text(), /consumed as an SSE stream/);
+    });
+
+    it("propagates a break to the handler's finally like a disconnect", async () => {
+        let cleanedUp = false;
+        const events = async function* (): AsyncGenerator<SseEvent> {
+            try {
+                yield { data: "one" };
+                yield { data: "two" };
+            } finally {
+                cleanedUp = true;
+            }
+        };
+        const router = new Router().route(
+            "/events",
+            m.get(() => new Sse(events())),
+        );
+
+        const res = await testClient(router).get("/events");
+
+        for await (const event of res.sseEvents()) {
+            assert.deepEqual(event, { data: "one" });
+            break;
+        }
+
+        for (let i = 0; i < 50 && !cleanedUp; i++) {
+            await new Promise((resolve) => {
+                setImmediate(resolve);
+            });
+        }
+
+        assert.equal(cleanedUp, true);
+    });
+
+    it("consumes a real Sse handler response end to end", async () => {
+        const events = async function* (): AsyncGenerator<SseEvent> {
+            yield { event: "created", data: JSON.stringify({ id: 1 }), id: "1" };
+            yield { data: "plain" };
+        };
+        const router = new Router().route(
+            "/events",
+            m.get(() => new Sse(events())),
+        );
+
+        const res = await testClient(router).get("/events");
+
+        assert.equal(res.headers.get("content-type"), "text/event-stream");
+        assert.deepEqual(await collect(res), [
+            { event: "created", data: '{"id":1}', id: "1" },
+            { data: "plain" },
+        ]);
+    });
+});

--- a/packages/testing/test/types.test.ts
+++ b/packages/testing/test/types.test.ts
@@ -1,0 +1,30 @@
+import type { TestClient } from "../src/index.js";
+
+/**
+ * Compile-time contract of the `TestRequest<BodySet>` type: once a body
+ * setter has been called, the body setters disappear from the type.
+ *
+ * These functions are never invoked; `tsc --noEmit` validates that every
+ * `@ts-expect-error` line fails to compile and every other line compiles.
+ */
+
+export const chainableAfterBody = (client: TestClient): void => {
+    void client.post("/").json({}).header("x-a", "1").query({ a: "1" });
+    void client.post("/").header("x-a", "1").json({});
+    void client.post("/").form({ a: "1" }).cookie("session", "abc");
+    void client.post("/").body("raw").extension;
+};
+
+export const noSecondBody = (client: TestClient): void => {
+    // @ts-expect-error a second body must not type-check
+    void client.post("/").json({}).body("again");
+
+    // @ts-expect-error a second body must not type-check
+    void client.post("/").json({}).form({ a: "1" });
+
+    // @ts-expect-error a second body must not type-check
+    void client.post("/").body("raw").json({});
+
+    // @ts-expect-error a second body must not type-check
+    void client.post("/").form({ a: "1" }).header("x-a", "1").body("late");
+};

--- a/packages/testing/tsconfig.build.json
+++ b/packages/testing/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+    "extends": ["./tsconfig.json"],
+    "compilerOptions": {
+        "rootDir": "src"
+    },
+    "exclude": ["test/**/*"]
+}

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": ["@tsconfig/node24/tsconfig.json"],
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "declaration": true,
+        "sourceMap": true,
+        "outDir": "dist",
+        "stripInternal": true,
+        "types": ["node"]
+    },
+    "include": ["src/**/*", "test/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,12 @@ importers:
         specifier: ^6.2.3
         version: 6.2.3
 
+  packages/testing:
+    devDependencies:
+      '@taxum/core':
+        specifier: workspace:*
+        version: link:../core
+
 packages:
 
   '@antfu/install-pkg@1.1.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,10 @@ importers:
         version: 6.2.3
 
   packages/testing:
+    dependencies:
+      set-cookie-parser:
+        specifier: ^3.1.2
+        version: 3.1.2
     devDependencies:
       '@taxum/core':
         specifier: workspace:*
@@ -1904,6 +1908,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3995,6 +4002,8 @@ snapshots:
       kind-of: 6.0.3
 
   semver@7.8.5: {}
+
+  set-cookie-parser@3.1.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
         "packages/cookie": {},
         "packages/core": {},
         "packages/fs": {},
-        "packages/jwt": {}
+        "packages/jwt": {},
+        "packages/testing": {}
     },
     "release-type": "node",
     "plugins": ["node-workspace"]


### PR DESCRIPTION
Adds @taxum/testing, an in-process test client: thenable request
builder over service.invoke(), fetch-flavored TestResponse with
wire-faithful normalization, RFC 6265 client cookie jar, and an
SSE event iterator. Includes a rewritten testing guide.

Release-As: 1.0.0